### PR TITLE
fix: :bug: Fix header include error

### DIFF
--- a/include/minishell.h
+++ b/include/minishell.h
@@ -1,19 +1,24 @@
 #ifndef MINISHELL_H
 # define MINISHELL_H
 
-// for window
+# ifdef WIN32
+#  include <sys/dirent.h>
+# else
+#  include <dirent.h>
+# endif
+
 # include <sys/stat.h>
 # include <fcntl.h>
 
 # include <stdio.h>
 # include <stdlib.h>
 # include <sys/types.h>
-# include <sys/dirent.h>
+
+# include "libft.h"
 
 # include <readline/readline.h>
 # include <readline/history.h>
 
-# include "libft.h"
 // # include "get_next_line.h"
 
 #endif

--- a/lib/include/color.h
+++ b/lib/include/color.h
@@ -1,5 +1,5 @@
-#ifndef COLORS_H
-# define COLORS_H
+#ifndef COLOR_H
+# define COLOR_H
 
 //	===== Regular text =====
 # define BLK "\e[0;30m"

--- a/makefile
+++ b/makefile
@@ -39,7 +39,7 @@ OBJ      := $(SRC:%.c=%.o)
 # @$(call build_library)
 $(NAME): $(OBJ)
 	make all -C lib/ DFLAGS="$(DFLAGS)"
-	@$(CC) $(CFLAGS) $(INC) $(LIB) -o $@ $^
+	@$(CC) $(CFLAGS) $(INC) $^ $(LIB) -o $@
 	@$(call log, V, 🚀 linked with flag $(R)$(DFLAGS)$(E)$(CFLAGS))
 
 all: $(NAME)
@@ -64,6 +64,7 @@ red: tclean docs all cls
 ald: docs all cls
 
 docs:
+	@make docs -C lib/
 	@set -e;\
 		for p in $(PKGS); do\
 			$(HGEN) -I include/$$p.h src/$$p;\


### PR DESCRIPTION
- 컴파일 시 라이브러리를 인자 목록 맨 뒤로 옮김
- 여전히 `libft.h`가 `readline` 위에 있어야 하는 것은 변함 없음

Fixes #30