### PR TITLE
feat: :sparkles: Add lexer_tokenizer

### DIFF
--- a/include/lexer.h
+++ b/include/lexer.h
@@ -1,0 +1,22 @@
+#ifndef LEXER_H
+# define LEXER_H
+
+typedef struct s_token
+{
+	t_tokentype	type;	
+	char		*text;
+}	t_token;
+
+//@func
+/*
+** < lexer.c > */
+
+t_token	*tokenizer(char *arr[]);
+/*
+** < lexer_tokenizer.c > */
+
+bool	is_metachar(t_token *token, const char *str);
+bool	is_expand_parameter(const char *str);
+void	token_print(t_token token[]);
+void	del_token(t_token token[]);
+#endif

--- a/include/lexer.h
+++ b/include/lexer.h
@@ -16,6 +16,7 @@ t_token	*tokenizer(char *arr[]);
 ** < lexer_tokenizer.c > */
 
 bool	is_metachar(t_token *token, const char *str);
+bool	is_quotes(const char *str);
 bool	is_expand_parameter(const char *str);
 void	token_print(t_token token[]);
 void	del_token(t_token token[]);

--- a/include/lexer.h
+++ b/include/lexer.h
@@ -11,13 +11,13 @@ typedef struct s_token
 /*
 ** < lexer.c > */
 
-t_token	*tokenizer(char *arr[]);
+t_token		*tokenizer(char *arr[]);
 /*
 ** < lexer_tokenizer.c > */
 
-bool	is_metachar(t_token *token, const char *str);
-bool	is_quotes(const char *str);
-bool	is_expand_parameter(const char *str);
-void	token_print(t_token token[]);
-void	del_token(t_token token[]);
+t_tokentype	tokentype_check(const char *str);
+bool		is_quotes(const char *str);
+bool		is_expand_parameter(const char *str);
+void		tokens_print(t_token tokens[]);
+void		del_tokens(t_token tokens[]);
 #endif

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -19,6 +19,9 @@
 # include <readline/readline.h>
 # include <readline/history.h>
 
+# include "minishell_type.h"
+# include "lexer.h"
+
 // # include "get_next_line.h"
 
 #endif

--- a/include/minishell_type.h
+++ b/include/minishell_type.h
@@ -1,0 +1,12 @@
+#ifndef MINISHELL_TYPE_H
+# define MINISHELL_TYPE_H
+
+typedef enum e_tokentype
+{
+	WORD = 0,
+	PIPELINE,
+	REDIRECT,
+	COMMAND,
+}	t_tokentype;
+
+#endif

--- a/makefile
+++ b/makefile
@@ -16,7 +16,9 @@ VFLAGS   := --leak-check=full --show-leak-kinds=all \
 HGEN     := hgen
 
 # ===== Packages =====
-PKGS     :=
+PKGS     := lexer
+
+lexerV   := lexer lexer_tokenizer
 
 # ===== Macros =====
 define choose_modules
@@ -38,7 +40,7 @@ OBJ      := $(SRC:%.c=%.o)
 
 # @$(call build_library)
 $(NAME): $(OBJ)
-	make all -C lib/ DFLAGS="$(DFLAGS)"
+	@make --no-print-directory all -C lib/ DFLAGS="$(DFLAGS)"
 	@$(CC) $(CFLAGS) $(INC) $^ $(LIB) -o $@
 	@$(call log, V, 🚀 linked with flag $(R)$(DFLAGS)$(E)$(CFLAGS))
 
@@ -64,7 +66,7 @@ red: tclean docs all cls
 ald: docs all cls
 
 docs:
-	@make docs -C lib/
+	@make --no-print-directory docs -C lib/
 	@set -e;\
 		for p in $(PKGS); do\
 			$(HGEN) -I include/$$p.h src/$$p;\

--- a/src/lexer/lexer.c
+++ b/src/lexer/lexer.c
@@ -2,25 +2,23 @@
 
 t_token	*tokenizer(char *arr[])
 {
-	t_token	*token;
+	t_token	*tokens;
 	int		len;
 	int		i;
 
 	len = ft_arr_len(arr);
-	token = (t_token *)malloc((len + 1) * sizeof(t_token));
-	if (!token)
+	tokens = (t_token *)malloc((len + 1) * sizeof(t_token));
+	if (!tokens)
 		return (NULL);
 	i = -1;
 	while (++i < len)
 	{
-		if (is_metachar(&token[i], arr[i]))
-			continue ;
-		token[i].type = WORD;
+		tokens[i].type = tokentype_check(arr[i]);
 		if (is_quotes(arr[i]) && !is_expand_parameter(arr[i]))
-			token[i].text = new_str_slice(arr[i], 1, ft_strlen(arr[i]) - 1);
+			tokens[i].text = new_str_slice(arr[i], 1, ft_strlen(arr[i]) - 1);
 		else
-			token[i].text = new_str(arr[i]);
+			tokens[i].text = new_str(arr[i]);
 	}
-	token[i].text = NULL;
-	return (token);
+	tokens[i].text = NULL;
+	return (tokens);
 }

--- a/src/lexer/lexer.c
+++ b/src/lexer/lexer.c
@@ -16,7 +16,7 @@ t_token	*tokenizer(char *arr[])
 		if (is_metachar(&token[i], arr[i]))
 			continue ;
 		token[i].type = WORD;
-		if (is_expand_parameter(arr[i]))
+		if (is_quotes(arr[i]) && !is_expand_parameter(arr[i]))
 			token[i].text = new_str_slice(arr[i], 1, ft_strlen(arr[i]) - 1);
 		else
 			token[i].text = new_str(arr[i]);

--- a/src/lexer/lexer.c
+++ b/src/lexer/lexer.c
@@ -1,0 +1,26 @@
+#include "minishell.h"
+
+t_token	*tokenizer(char *arr[])
+{
+	t_token	*token;
+	int		len;
+	int		i;
+
+	len = ft_arr_len(arr);
+	token = (t_token *)malloc((len + 1) * sizeof(t_token));
+	if (!token)
+		return (NULL);
+	i = -1;
+	while (++i < len)
+	{
+		if (is_metachar(&token[i], arr[i]))
+			continue ;
+		token[i].type = WORD;
+		if (is_expand_parameter(arr[i]))
+			token[i].text = new_str_slice(arr[i], 1, ft_strlen(arr[i]) - 1);
+		else
+			token[i].text = new_str(arr[i]);
+	}
+	token[i].text = NULL;
+	return (token);
+}

--- a/src/lexer/lexer_tokenizer.c
+++ b/src/lexer/lexer_tokenizer.c
@@ -1,0 +1,45 @@
+#include "minishell.h"
+
+bool	is_metachar(t_token *token, const char *str)
+{
+	if (is_str_equal(str, "|"))
+		token->type = PIPELINE;
+	else if (is_str_equal(str, ";"))
+		token->type = COMMAND;
+	else if (is_str_equal(str, "<") || is_str_equal(str, "<<")
+		|| is_str_equal(str, ">") || is_str_equal(str, ">>"))
+		token->type = REDIRECT;
+	else
+		return (false);
+	token->text = new_str(str);
+	return (true);
+}
+
+bool	is_expand_parameter(const char *str)
+{
+	if (str[0] == '\'' || (str[0] == '\"' && (ft_strchr_i(str, '$') == ERR)))
+		return (true);
+	return (false);
+}
+
+void	token_print(t_token token[])
+{
+	int	i;
+
+	i = 0;
+	while (token[i].text)
+	{
+		printf("[%d] text: %s\ttype: %d\n", i, token[i].text, token[i].type);
+		i++;
+	}
+}
+
+void	del_token(t_token token[])
+{
+	int	i;
+
+	i = -1;
+	while (token[++i].text)
+		free(token[i].text);
+	free(token);
+}

--- a/src/lexer/lexer_tokenizer.c
+++ b/src/lexer/lexer_tokenizer.c
@@ -15,9 +15,16 @@ bool	is_metachar(t_token *token, const char *str)
 	return (true);
 }
 
+bool	is_quotes(const char *str)
+{
+	if (str[0] == '\'' || str[0] == '\"')
+		return (true);
+	return (false);
+}
+
 bool	is_expand_parameter(const char *str)
 {
-	if (str[0] == '\'' || (str[0] == '\"' && (ft_strchr_i(str, '$') == ERR)))
+	if (str[0] == '\"' && (ft_strchr_i(str, '$') != ERR))
 		return (true);
 	return (false);
 }

--- a/src/lexer/lexer_tokenizer.c
+++ b/src/lexer/lexer_tokenizer.c
@@ -1,18 +1,15 @@
 #include "minishell.h"
 
-bool	is_metachar(t_token *token, const char *str)
+t_tokentype	tokentype_check(const char *str)
 {
 	if (is_str_equal(str, "|"))
-		token->type = PIPELINE;
-	else if (is_str_equal(str, ";"))
-		token->type = COMMAND;
-	else if (is_str_equal(str, "<") || is_str_equal(str, "<<")
+		return (PIPELINE);
+	if (is_str_equal(str, ";"))
+		return (COMMAND);
+	if (is_str_equal(str, "<") || is_str_equal(str, "<<")
 		|| is_str_equal(str, ">") || is_str_equal(str, ">>"))
-		token->type = REDIRECT;
-	else
-		return (false);
-	token->text = new_str(str);
-	return (true);
+		return (REDIRECT);
+	return (WORD);
 }
 
 bool	is_quotes(const char *str)
@@ -29,24 +26,24 @@ bool	is_expand_parameter(const char *str)
 	return (false);
 }
 
-void	token_print(t_token token[])
+void	tokens_print(t_token tokens[])
 {
 	int	i;
 
 	i = 0;
-	while (token[i].text)
+	while (tokens[i].text)
 	{
-		printf("[%d] text: %s\ttype: %d\n", i, token[i].text, token[i].type);
+		printf("[%d] text: %s\ttype: %d\n", i, tokens[i].text, tokens[i].type);
 		i++;
 	}
 }
 
-void	del_token(t_token token[])
+void	del_tokens(t_token tokens[])
 {
 	int	i;
 
 	i = -1;
-	while (token[++i].text)
-		free(token[i].text);
-	free(token);
+	while (tokens[++i].text)
+		free(tokens[i].text);
+	free(tokens);
 }


### PR DESCRIPTION
문자열 배열을 t_token 배열로 변환하는 tokenizer 구현
- t_token 구조체, t_tokentype enum 정의
- lexer.c에는 tokenizer() 함수만 정의
- tokenizer()에 쓰이는 내부 함수들은 lexer_tokenizer.c에 정의

closes #18