### PR TITLE
feat: :sparkles: Improve lexer_tokenizer

### DIFF
--- a/include/lexer.h
+++ b/include/lexer.h
@@ -16,7 +16,7 @@ t_token		*tokenizer(char *arr[]);
 ** < lexer_tokenizer.c > */
 
 t_AST_type	tokentype_check(const char *str);
-bool		is_quotes(const char *str);
+int			quotes_index(const char *str);
 bool		is_expand_parameter(const char *str);
 void		tokens_print(t_token tokens[]);
 void		del_tokens(t_token tokens[]);

--- a/src/lexer/lexer.c
+++ b/src/lexer/lexer.c
@@ -1,10 +1,32 @@
 #include "minishell.h"
 
+static char	*new_quotes_remove(char *str, int quote_i)
+{
+	char	**split_words;
+	char	*new;
+
+	split_words = new_str_split(str, str[quote_i]);
+	new = new_str_join(split_words, '\0');
+	del_arr(split_words);
+	return (new);
+}
+
+static char	*new_expand_parameter(char *str)
+{
+	char	*new;
+
+	new = new_str("\"");
+	ft_str_append(&new, str);
+	ft_str_append(&new, "\"");
+	return (new);
+}
+
 t_token	*tokenizer(char *arr[])
 {
 	t_token	*tokens;
 	int		len;
 	int		i;
+	int		quote_i;
 
 	len = ft_arr_len(arr);
 	tokens = (t_token *)malloc((len + 1) * sizeof(t_token));
@@ -14,11 +36,15 @@ t_token	*tokenizer(char *arr[])
 	while (++i < len)
 	{
 		tokens[i].type = tokentype_check(arr[i]);
-		if (is_quotes(arr[i]) && !is_expand_parameter(arr[i]))
-			tokens[i].text = new_str_slice(arr[i], 1, ft_strlen(arr[i]) - 1);
+		quote_i = quotes_index(arr[i]);
+		if (quote_i != ERR && !is_expand_parameter(arr[i]))
+			tokens[i].text = new_quotes_remove(arr[i], quote_i);
+		else if (quote_i == ERR && ft_strchr_i(arr[i], '$') != ERR)
+			tokens[i].text = new_expand_parameter(arr[i]);
 		else
 			tokens[i].text = new_str(arr[i]);
 	}
 	tokens[i].text = NULL;
+	del_arr(arr);
 	return (tokens);
 }

--- a/src/lexer/lexer_tokenizer.c
+++ b/src/lexer/lexer_tokenizer.c
@@ -12,16 +12,37 @@ t_AST_type	tokentype_check(const char *str)
 	return (WORD);
 }
 
-bool	is_quotes(const char *str)
+int	quotes_index(const char *str)
 {
-	if (str[0] == '\'' || str[0] == '\"')
-		return (true);
-	return (false);
+	const int	single_i = ft_strchr_i(str, '\'');
+	const int	double_i = ft_strchr_i(str, '\"');
+
+	if (single_i != ERR && double_i != ERR)
+	{
+		if (single_i < double_i)
+			return (single_i);
+		else
+			return (double_i);
+	}
+	if (single_i != ERR)
+		return (single_i);
+	if (double_i != ERR)
+		return (double_i);
+	return (ERR);
 }
 
 bool	is_expand_parameter(const char *str)
 {
-	if (str[0] == '\"' && (ft_strchr_i(str, '$') != ERR))
+	const int	expand_i = ft_strchr_i(str, '$');
+	const int	single_i = ft_strchr_i(str, '\'');
+	const int	start_i = ft_strchr_i(str, '\"');
+	int			end_i;
+
+	if (start_i == ERR || expand_i == ERR
+		|| (single_i != ERR && start_i > single_i))
+		return (false);
+	end_i = ft_strchr_i(&str[start_i + 1], '\"') + start_i + 1;
+	if (expand_i > start_i && expand_i < end_i)
 		return (true);
 	return (false);
 }
@@ -35,8 +56,8 @@ void	tokens_print(t_token tokens[])
 
 	i = -1;
 	while (tokens[++i].text)
-		printf("[%2d] " BGRN "%-12s" END "%s\n" END,
-			i, tokens[i].text, type_str[tokens[i].type]);
+		printf("[%2d] %-12s" BGRN "\t%s\n" END,
+			i, type_str[tokens[i].type], tokens[i].text);
 }
 
 void	del_tokens(t_token tokens[])


### PR DESCRIPTION
# tokenizer 문자열 처리 기능 추가
## `"`과 `'`로 감싸진 문자열이 중간에 있어도 처리 가능
### is_quotes() -> quotes_index()
- 따옴표의 index를 반환하는 함수로 변경
- mandatory에서는 따옴표가 딱 한 쌍으로만 쓰이는 경우를 대비하면 되지만, 혹시 몰라서 둘 다 쓰였을 경우도 대비
- 같은 것을 두 번 쓰는 escape 문자가 아니라 두 종류가 함께 쓰였을 경우 `'""'` or `"''"`

### is_expand_parameter() 조건 추가
-  `"`으로 감싸진 구간에 `$`이 있는 경우를 검사
- 여기서도 `'"$HOME"'`과 같은 경우는 그대로 출력하도록 조건 추가
- 따옴표의 짝이 맞는 것은 scanner 단계에서 검사해서 넘어온다는 가정이 깔려있어 end_i가 ERR인 경우는 고려X
---

## 따옴표 없는 expansion 문자열(환경변수)도 parser에서 구분할 수 있게 처리
- `$HOME`과 `'$HOME'`의 처리된 문자열이 똑같으면 구분할 수 없으므로, `"`로 감싸주어 expansion 문자열을 표시
---

### 메모리누수 처리 완료 
- 입력받은 문자열 배열은 더이상 사용X -> del_arr()

### tokens_print() 출력 순서 변경
- 문자열이 길어질 때를 대비해 type이 먼저 나오도록 수정

closes #36