### PR TITLE
fix: 🐛 Make arrays in ast node able to be NULL terminated

### DIFF
--- a/include/ast_node.h
+++ b/include/ast_node.h
@@ -6,7 +6,7 @@
 typedef struct s_AST_WORD
 {
 	char			*text;
-	t_AST_expansion	*expansion;
+	t_AST_expansion	**expansions;
 }	t_AST_WORD;
 
 typedef struct s_AST_REDIRECT
@@ -28,11 +28,14 @@ typedef struct s_AST_suffix
 typedef struct s_AST_COMMAND
 {
 	t_AST_WORD		name;
-	t_AST_REDIRECT	*prefix;
-	t_AST_suffix	*suffix;
+	t_AST_REDIRECT	**prefixes;
+	t_AST_suffix	**suffixes;
 }	t_AST_COMMAND;
 
-typedef t_AST_COMMAND*		t_AST_PIPELINE;
+typedef struct s_AST_PIPELINE
+{
+	t_AST_COMMAND	**commands;
+}	t_AST_PIPELINE;
 
 typedef struct s_AST_SCRIPT_elem
 {
@@ -44,6 +47,9 @@ typedef struct s_AST_SCRIPT_elem
 	}	u_data;
 }	t_AST_SCRIPT_elem;
 
-typedef t_AST_SCRIPT_elem*	t_AST_SCRIPT;
+typedef struct s_AST_SCRIPT
+{
+	t_AST_SCRIPT_elem	**elems;
+}	t_AST_SCRIPT;
 
 #endif

--- a/include/ast_node.h
+++ b/include/ast_node.h
@@ -15,7 +15,7 @@ typedef struct s_AST_REDIRECT
 	t_redirect_op	op;
 }	t_AST_REDIRECT;
 
-typedef struct s_AST_suffix
+typedef struct s_AST_node
 {
 	t_AST_type			type;
 	union
@@ -23,13 +23,13 @@ typedef struct s_AST_suffix
 		t_AST_WORD		word;
 		t_AST_REDIRECT	redirection;
 	}	u_data;
-}	t_AST_suffix;
+}	t_AST_node;
 
 typedef struct s_AST_COMMAND
 {
 	t_AST_WORD		name;
 	t_AST_REDIRECT	**prefixes;
-	t_AST_suffix	**suffixes;
+	t_AST_node		**suffixes;
 }	t_AST_COMMAND;
 
 typedef struct s_AST_PIPELINE

--- a/lib/include/ft_math.h
+++ b/lib/include/ft_math.h
@@ -5,6 +5,7 @@
 /*
 ** < math.c > */
 
-int	ft_digit_len(int n);
-int	ft_max(int a, int b);
+int		ft_digit_len(int n);
+int		ft_max(int a, int b);
+char	*new_itoa(int n);
 #endif

--- a/lib/src/ft_math/math.c
+++ b/lib/src/ft_math/math.c
@@ -19,3 +19,31 @@ int	ft_max(int a, int b)
 		return (a);
 	return (b);
 }
+
+char	*new_itoa(int n)
+{
+	char	*str;
+	int		digit;
+	long	num;
+
+	num = n;
+	if (num == 0)
+		return (new_str("0"));
+	digit = ft_digit_len(num);
+	if (num < 0)
+		digit++;
+	str = ft_calloc(sizeof(char), digit);
+	if (!str)
+		return (NULL);
+	if (num < 0)
+	{
+		num = -num;
+		str[0] = '-';
+	}
+	while (num > 0)
+	{
+		str[--digit] = '0' + (num % 10);
+		num /= 10;
+	}
+	return (str);
+}

--- a/lib/src/system/calloc.c
+++ b/lib/src/system/calloc.c
@@ -4,7 +4,7 @@ void	*ft_calloc(size_t size, size_t count)
 {
 	size_t			i;
 	char			*ptr;
-	const size_t	allocated_space = count * (size + 1);
+	const size_t	allocated_space = size * (count + 1);
 
 	ptr = malloc(allocated_space);
 	if (!ptr)


### PR DESCRIPTION
- `t_AST_SCRIPT`, `t_AST_PIPELINE`을 구조체로 변경
- `t_AST_suffix` 를 `t_AST_node`로 변경 (가독성 고려)
- fixes #48
- fixes #46 