### PR TITLE
feat: :sparkles: Use linked list instead of array for scanner

### DIFF
--- a/include/lexer.h
+++ b/include/lexer.h
@@ -1,6 +1,12 @@
 #ifndef LEXER_H
 # define LEXER_H
 
+typedef struct s_scan_node
+{
+	char				*text;
+	t_AST_expansion		**expansion;
+}	t_scan_node;
+
 typedef struct s_token
 {
 	t_AST_type	type;
@@ -9,20 +15,14 @@ typedef struct s_token
 
 //@func
 /*
+** < expansion.c > */
+
+void		del_expansion_arr(t_AST_expansion *arr[]);
+/*
 ** < lexer.c > */
 
-t_res		scanner(char **scan_data[], char *line);
+t_res		scanner(t_list **scan_list, char *line);
 t_token		*tokenizer(char *arr[]);
-/*
-** < scanner_util.c > */
-
-bool		is_quotes_open(char *str);
-t_res		buf_to_arr(char **parr[], char **buf);
-t_res		whitespace_scan(char **arr[], char **buf, char *str, int *idx);
-/*
-** < scanner_util2.c > */
-
-t_res		metachar_scan(char **arr[], char **buf, char *str, int *idx);
 /*
 ** < lexer_tokenizer.c > */
 
@@ -31,6 +31,22 @@ int			quotes_index(const char *str);
 bool		is_expand_parameter(const char *str);
 void		tokens_print(t_token tokens[]);
 void		del_tokens(t_token tokens[]);
+/*
+** < scanner_list.c > */
+
+t_scan_node	*new_scan_node(char *str, t_AST_expansion **arr);
+void		del_scan_node(void *param);
+void		scan_node_print(void *param);
+/*
+** < scanner_util.c > */
+
+bool		is_quotes_open(char *str);
+t_res		buf_to_list(t_list **list, char **buf);
+t_res		whitespace_scan(t_list **list, char **buf, char *str, int *idx);
+/*
+** < scanner_util2.c > */
+
+t_res		metachar_scan(t_list **list, char **buf, char *str, int *idx);
 /*
 ** < util.c > */
 

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -16,12 +16,13 @@ HGEN     := hgen
 TEST     := test
 
 # ===== Packages =====
-PKGS     := string dict system ft_math
+PKGS     := string dict system ft_math list
 
 stringV  := new util array split join
 dictV    := new del util hash set get expand print status
 systemV  := calloc
 ft_mathV := math
+listV    := list
 
 # ===== Macros =====
 define choose_modules

--- a/lib/include/libft.h
+++ b/lib/include/libft.h
@@ -14,5 +14,6 @@
 # include "system.h"
 # include "color.h"
 # include "dict.h"
+# include "list.h"
 
 #endif

--- a/lib/include/list.h
+++ b/lib/include/list.h
@@ -1,0 +1,22 @@
+#ifndef LIST_H
+# define LIST_H
+
+typedef struct s_list
+{
+	void			*content;
+	struct s_list	*next;
+}	t_list;
+
+typedef void	(*t_del_f)(void *param);
+typedef void	(*t_print_f)(void *param);
+
+//@func
+/*
+** < list.c > */
+
+t_list	*new_list(void *content);
+int		ft_list_size(t_list *list);
+void	ft_list_append(t_list **list, t_list *new_node);
+void	del_list(t_list **list, t_del_f del);
+void	ft_list_print(t_list *list, t_print_f print_func);
+#endif

--- a/lib/src/list/list.c
+++ b/lib/src/list/list.c
@@ -1,0 +1,74 @@
+#include "libft.h"
+
+t_list	*new_list(void *content)
+{
+	t_list	*new_list;
+
+	new_list = (t_list *)malloc(sizeof(t_list));
+	if (new_list == NULL)
+		return (NULL);
+	new_list->content = content;
+	new_list->next = NULL;
+	return (new_list);
+}
+
+int	ft_list_size(t_list *list)
+{
+	t_list	*current;
+	int		size;
+
+	current = list;
+	size = 0;
+	while (current != NULL)
+	{
+		size++;
+		current = current->next;
+	}
+	return (size);
+}
+
+void	ft_list_append(t_list **list, t_list *new_node)
+{
+	t_list	*current;
+
+	current = *list;
+	if (*list == NULL)
+		*list = new_node;
+	else
+	{
+		while (current->next != NULL)
+			current = current->next;
+		current->next = new_node;
+	}
+}
+
+void	del_list(t_list **list, t_del_f del)
+{
+	t_list	*current;
+
+	while (*list != NULL)
+	{
+		current = *list;
+		*list = (*list)->next;
+		del(current->content);
+		free(current);
+	}
+	*list = NULL;
+}
+
+void	ft_list_print(t_list *list, t_print_f print_func)
+{
+	t_list 		*current;
+	int			i;
+	const int	len = ft_list_size(list);
+	const int	pad = ft_digit_len(len - 1);
+
+	current = list;
+	i = 0;
+	while (current != NULL)
+	{
+		printf(BHYEL "[%*d] " END, pad, i++);
+		print_func(current->content);
+		current = current->next;
+	}
+}

--- a/makefile
+++ b/makefile
@@ -19,7 +19,8 @@ HGEN     := hgen
 # ===== Packages =====
 PKGS     := prompt lexer builtin
 
-lexerV   := lexer scanner_util scanner_util2 lexer_tokenizer util
+lexerV   := lexer scanner_list scanner_util scanner_util2 \
+			lexer_tokenizer util expansion
 promptV  := prompt interrupt util
 builtinV := env path
 

--- a/src/lexer/expansion.c
+++ b/src/lexer/expansion.c
@@ -1,0 +1,11 @@
+#include "minishell.h"
+
+void	del_expansion_arr(t_AST_expansion *arr[])
+{
+	int	i;
+
+	i = -1;
+	while (arr[++i] != NULL)
+		free(arr[i]);
+	free(arr);
+}

--- a/src/lexer/lexer.c
+++ b/src/lexer/lexer.c
@@ -1,6 +1,6 @@
 #include "minishell.h"
 
-t_res	scanner(char **scan_data[], char *line)
+t_res	scanner(t_list **scan_list, char *line)
 {
 	char	*buf;
 	int		i;
@@ -10,9 +10,9 @@ t_res	scanner(char **scan_data[], char *line)
 	i = -1;
 	while (line[++i])
 	{
-		if (whitespace_scan(scan_data, &buf, line, &i) == OK)
+		if (whitespace_scan(scan_list, &buf, line, &i) == OK)
 			continue ;
-		scan_res = metachar_scan(scan_data, &buf, line, &i);
+		scan_res = metachar_scan(scan_list, &buf, line, &i);
 		if (scan_res == OK)
 			continue ;
 		if (scan_res == ERR)
@@ -22,7 +22,7 @@ t_res	scanner(char **scan_data[], char *line)
 		}
 		ft_str_append(&buf, line[i]);
 	}
-	buf_to_arr(scan_data, &buf);
+	buf_to_list(scan_list, &buf);
 	free(buf);
 	return (OK);
 }

--- a/src/lexer/scanner_list.c
+++ b/src/lexer/scanner_list.c
@@ -1,0 +1,40 @@
+#include "minishell.h"
+
+t_scan_node	*new_scan_node(char *str, t_AST_expansion **arr)
+{
+	t_scan_node	*new;
+
+	new = (t_scan_node *)malloc(sizeof(t_scan_node));
+	if (!new)
+		return (NULL);
+	new->text = str;
+	new->expansion = arr;
+	return (new);
+}
+
+void	del_scan_node(void *param)
+{
+	t_scan_node	*node;
+
+	node = (t_scan_node *)param;
+	free(node->text);
+	if (node->expansion)
+		del_expansion_arr(node->expansion);
+	free(node);
+}
+
+void	scan_node_print(void *param)
+{
+	t_scan_node	*node;
+	int			i;
+
+	node = (t_scan_node *)param;
+	printf("\"" HGRN "%s" END "\"\n", node->text);
+	if (node->expansion)
+	{
+		i = -1;
+		while (node->expansion[++i] != NULL)
+			printf("(%s -> %d, %d)\n", node->expansion[i]->parameter,
+				node->expansion[i]->begin, node->expansion[i]->end);
+	}
+}

--- a/src/lexer/scanner_util.c
+++ b/src/lexer/scanner_util.c
@@ -23,26 +23,26 @@ bool	is_quotes_open(char *str)
 	return (false);
 }
 
-t_res	buf_to_arr(char **parr[], char **buf)
+t_res	buf_to_list(t_list **list, char **buf)
 {
 	const int	buf_len = ft_strlen(*buf);
 
 	if (buf_len == 0)
 		return (UNSET);
-	ft_arr_append(parr, *buf);
+	ft_list_append(list, new_list(new_scan_node(new_str(*buf), NULL)));
 	free(*buf);
 	*buf = new_str("");
 	return (OK);
 }
 
-t_res	whitespace_scan(char **arr[], char **buf, char *str, int *idx)
+t_res	whitespace_scan(t_list **list, char **buf, char *str, int *idx)
 {
 	int	i;
 
 	i = *idx;
 	if (is_whitespace(str[i]) && !is_quotes_open(*buf))
 	{
-		buf_to_arr(arr, buf);
+		buf_to_list(list, buf);
 		while (is_whitespace(str[++i]))
 			;
 		*idx = --i;

--- a/src/lexer/scanner_util2.c
+++ b/src/lexer/scanner_util2.c
@@ -16,11 +16,11 @@ static bool	is_prev_metachar_attachable(char *str)
 }
 
 static t_res	metastr_append(
-	char **arr[], char **prev_pstr, char **pstr, char c)
+	t_list **list, char **prev_pstr, char **pstr, char c)
 {
 	if (is_prev_metachar_attachable(*prev_pstr))
 	{
-		ft_arr_append(arr, *pstr);
+		ft_list_append(list, new_list(new_scan_node(new_str(*pstr), NULL)));
 		if (!c)
 			return (UNSET);
 		free(*prev_pstr);
@@ -38,7 +38,7 @@ static t_res	metastr_append(
 	}
 }
 
-static bool	is_metachar_valid(char **arr[], char *str, int *idx)
+static bool	is_metachar_valid(t_list **list, char *str, int *idx)
 {
 	char	*metastr;
 	char	*prev_metastr;
@@ -52,26 +52,26 @@ static bool	is_metachar_valid(char **arr[], char *str, int *idx)
 	{
 		if (metachar_attachable(&metastr, str[i - 1], str[i]) == OK)
 			continue ;
-		res = metastr_append(arr, &prev_metastr, &metastr, str[i]);
+		res = metastr_append(list, &prev_metastr, &metastr, str[i]);
 		if (res == UNSET)
 			break ;
 		if (res == ERR)
 			return (false);
 	}
 	if (str[i] && is_prev_metachar_attachable(prev_metastr))
-		ft_arr_append(arr, metastr);
+		ft_list_append(list, new_list(new_scan_node(new_str(metastr), NULL)));
 	*idx = --i;
 	free(metastr);
 	free(prev_metastr);
 	return (true);
 }
 
-t_res	metachar_scan(char **arr[], char **buf, char *str, int *idx)
+t_res	metachar_scan(t_list **list, char **buf, char *str, int *idx)
 {
 	if (is_metachar(str[*idx]) && !is_quotes_open(*buf))
 	{
-		buf_to_arr(arr, buf);
-		if (!is_metachar_valid(arr, str, idx))
+		buf_to_list(list, buf);
+		if (!is_metachar_valid(list, str, idx))
 			return (ERR);
 		return (OK);
 	}


### PR DESCRIPTION
기존 scanner의 반환값을 문자열배열에서 연결리스트로 변경
---
closes #54 
### 연결리스트 사용을 위한 라이브러리 함수 추가
```c
t_list	*new_list(void *content);
int     ft_list_size(t_list *list);
void	ft_list_append(t_list **list, t_list *new_node);
void	del_list(t_list **list, t_del_f del);
void	ft_list_print(t_list *list, t_print_f print_func);
```
- ft_list_append() 함수는 새로운 노드를 뒤에 추가해주는 함수
---

closes #55 
### scanner에서 사용할 연결리스트의 content = t_scan_node
```c
typedef struct s_scan_node
{
	char			*text;
	t_AST_expansion		**expansion;
}	t_scan_node;
```
```c
t_scan_node	*new_scan_node(char *str, t_AST_expansion **arr);
```
- t_scan_node 생성
- 지금까지 작성된 공백, 구분문자의 경우 node 추가시 expansion arr가 NULL

```c
void		del_scan_node(void *param);
void		scan_node_print(void *param);
void		del_expansion_arr(t_AST_expansion *arr[]);
```
- node 출력과 삭제를 위한 함수

### scanner 함수에서 문자열배열을 연결리스트로 교체
```c
t_res		buf_to_list(t_list **list, char **buf);
t_res		whitespace_scan(t_list **list, char **buf, char *str, int *idx);
t_res		metachar_scan(t_list **list, char **buf, char *str, int *idx);
```
- `char **arr[]`를 `t_list **list`로 변경