### PR TITLE
feat: :sparkles: Add expansion scan

### DIFF
--- a/include/lexer.h
+++ b/include/lexer.h
@@ -1,6 +1,18 @@
 #ifndef LEXER_H
 # define LEXER_H
 
+typedef struct	s_expansion_scan_info
+{
+	char			**buf;
+	char			*str;
+	int				*idx;
+	int				start_i;
+	t_AST_expansion	**expansions;
+	int				begin;
+	int				end;
+
+}	t_expansion_scan_info;
+
 typedef struct s_scan_node
 {
 	char				*text;
@@ -66,4 +78,11 @@ bool		is_whitespace(char c);
 bool		is_quotechar(char c);
 bool		is_alpha(char c);
 bool		is_digit(char c);
+/*
+** < util2.c > */
+
+bool		is_1stchar_valid(char c);
+bool		is_variable_char_valid(char c);
+bool		is_scan_continuos(char *buf, char c);
+bool		is_multi_expansions(t_expansion_scan_info info, int i);
 #endif

--- a/makefile
+++ b/makefile
@@ -19,7 +19,7 @@ HGEN     := hgen
 # ===== Packages =====
 PKGS     := prompt lexer parser api builtin tree
 
-lexerV   := lexer scanner expansion util \
+lexerV   := lexer scanner expansion util util2 \
 			scanner_list scanner_util scanner_util2 scanner_util3 \
 			lexer_tokenizer
 parserV  := new1 new2 del

--- a/src/lexer/expansion.c
+++ b/src/lexer/expansion.c
@@ -43,5 +43,5 @@ void	expansions_print(t_AST_expansion *expansions[])
 	i = -1;
 	while (expansions[++i])
 		printf(BLU "\t[%d] (%s -> %d, %d)\n" END, i, expansions[i]->parameter,
-				expansions[i]->begin, expansions[i]->end);
+			expansions[i]->begin, expansions[i]->end);
 }

--- a/src/lexer/scanner.c
+++ b/src/lexer/scanner.c
@@ -13,24 +13,6 @@ static t_res	error_unclosed(char c, char **buf)
 	return (free_n_return(buf, ERR));
 }
 
-static t_res	dollar_scan(t_list **list, char **buf, char *str, int *idx)
-{
-	int		i;
-	char	last_quote;
-	(void)list;
-
-	i = *idx;
-	if (str[i] == '$')
-	{
-		if (is_quotes_open(&last_quote, *buf) && last_quote == '\'')
-			return (UNSET);
-		printf("%s$\n", *buf);
-		ft_str_append(buf, '$');
-		return (OK);
-	}
-	return (UNSET);
-}
-
 static t_res	scanner_loop(t_list **scan_list, char *line, char **buf, int *i)
 {
 	t_res	scan_res;

--- a/src/lexer/scanner_util3.c
+++ b/src/lexer/scanner_util3.c
@@ -1,2 +1,83 @@
 #include "minishell.h"
 
+static t_res	expansions_update(t_expansion_scan_info *info, int end)
+{
+	char	*parameter;
+
+	info->end = end - *info->idx + info->start_i;
+	parameter = new_str_slice(*info->buf, info->begin + 1, info->end + 1);
+	expansions_append_free(&info->expansions,
+		new_ast_expansion(parameter, info->begin, info->end));
+	free(parameter);
+	return (OK);
+}
+
+static t_res	expansion_location_init(t_expansion_scan_info *info, int *i)
+{
+	info->begin = *i - *info->idx + info->start_i;
+	ft_str_extend(info->buf, (char []){'$', info->str[++*i], '\0'});
+	info->end = -1;
+	return (OK);
+}
+
+static t_res	expansion_scan_loop(t_expansion_scan_info *info, int *i)
+{
+	while (is_scan_continuos(*info->buf, info->str[++*i]))
+	{
+		if (!is_variable_char_valid(info->str[*i]))
+		{
+			if (info->end < info->begin)
+				expansions_update(info, *i - 1);
+			if (is_multi_expansions(*info, *i)
+				&& expansion_location_init(info, i) == OK)
+				continue ;
+		}
+		ft_str_append(info->buf, info->str[*i]);
+	}
+	if (info->end < info->begin)
+		expansions_update(info, *i - 1);
+	return (OK);
+}
+
+t_res	expansion_scan(t_list **list, char **buf, char *str, int *idx)
+{
+	t_expansion_scan_info	info;
+	int						i;
+
+	info.buf = buf;
+	info.str = str;
+	info.idx = idx;
+	info.expansions = new_ast_expansions((t_AST_expansion *[]){NULL});
+	info.start_i = ft_strlen(*buf);
+	i = *info.idx;
+	if (!is_1stchar_valid(str[i + 1]))
+		return (UNSET);
+	expansion_location_init(&info, &i);
+	expansion_scan_loop(&info, &i);
+	ft_list_append(list, new_list(
+			new_scan_node(new_str(*info.buf), info.expansions)));
+	*idx = --i;
+	return (OK);
+}
+
+t_res	dollar_scan(t_list **list, char **buf, char *str, int *idx)
+{
+	int		i;
+	char	last_quote;
+	t_res	res;
+
+	i = *idx;
+	if (str[i] == '$')
+	{
+		if (is_quotes_open(&last_quote, *buf) && last_quote == '\'')
+			return (UNSET);
+		res = expansion_scan(list, buf, str, &i);
+		if (res == UNSET)
+			return (UNSET);
+		*idx = i;
+		free(*buf);
+		*buf = new_str("");
+		return (OK);
+	}
+	return (UNSET);
+}

--- a/src/lexer/util.c
+++ b/src/lexer/util.c
@@ -20,3 +20,17 @@ bool	is_quotechar(char c)
 		return (true);
 	return (false);
 }
+
+bool	is_alpha(char c)
+{
+	if ((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z'))
+		return (true);
+	return (false);
+}
+
+bool	is_digit(char c)
+{
+	if (c >= '0' && c <= '9')
+		return (true);
+	return (false);
+}

--- a/src/lexer/util2.c
+++ b/src/lexer/util2.c
@@ -1,0 +1,33 @@
+#include "minishell.h"
+
+bool	is_1stchar_valid(char c)
+{
+	if (is_alpha(c) || c == '{' || c == '_')
+		return (true);
+	return (false);
+}
+
+bool	is_variable_char_valid(char c)
+{
+	if (is_alpha(c) || is_digit(c) || c == '_' || c == '}')
+		return (true);
+	return (false);
+}
+
+bool	is_scan_continuos(char *buf, char c)
+{
+	if (!c || (!is_quotes_open(NULL, buf)
+			&& (is_whitespace(c) || is_metachar(c))))
+		return (false);
+	return (true);
+}
+
+bool	is_multi_expansions(t_expansion_scan_info info, int i)
+{
+	char	last_quote;
+
+	if (info.str[i] == '$' && is_1stchar_valid(info.str[i + 1])
+		&& (!is_quotes_open(&last_quote, *info.buf) || last_quote != '\''))
+		return (true);
+	return (false);
+}


### PR DESCRIPTION
### 개요
$기호가 환경변수 치환이 필요한 경우인지 판단하는 함수 추가
- ${NAME}에 대한 추가 처리 필요
- 다소 비효율적으로 보일 수 있음 주의 :cry: 

### API

```c
t_res	dollar_scan(t_list **list, char **buf, char *str, int *idx);
```
- $가 그냥 문자열로 출력해야하는지(`'`문자열 안에 있는 경우) 확인

```c
t_res	expansion_scan(t_list **list, char **buf, char *str, int *idx);
```
- $다음에 변수명으로 사용할 수 없는 기호들이 온 경우, 그냥 출력할 수 있도록 UNSET
- 그 외의 경우는 expansion이 있다는 것으로 간주해 expansion 배열에 담을 준비 후 scan 시작
- 생성된 expansions를 buf와 함께 list에 추가

### 구현

```c
typedef struct	s_expansion_scan_info
{
	char			**buf;
	char			*str;
	int				*idx;
	int				start_i;
	t_AST_expansion	**expansions;
	int				begin;
	int				end;

}	t_expansion_scan_info;
```
- 계산에 필요한 변수가 많아서, 일단 전부 다 info 구조체에 넣고 시작

```c
static t_res	expansion_scan_loop(t_expansion_scan_info *info, int *i);
```
- $가 포함된 문자열이 하나의 buf로 담길 수 있을 때까지 반복해서 체크하는 함수

```c
static t_res	expansion_location_init(t_expansion_scan_info *info, int *i);
static t_res	expansions_update(t_expansion_scan_info *info, int end);
```
1. expansion의 location에 해당하는 begin과 end를 초기화
2. 주어진 end에 의해 expansion을 생성해서 expansions에 붙여주는 작업

```c
bool	is_1stchar_valid(char c);
bool	is_variable_char_valid(char c);
bool	is_scan_continuos(char *buf, char c);
bool	is_multi_expansions(t_expansion_scan_info info, int i);
```
1. $뒤에 왔을 때 변수명으로 인정할 수 있는 문자 확인
2. 변수명에 포함될 수 있는 문자 확인
3. buf에 담길 문자열이 끝나지 않았는지 확인 (문자열의 끝 or 제대로 닫힌 문자열 뒤에 구분문자가 온 경우 false)
4. 하나로 쭉 연결된 문자열 속에서 환경변수로 치환가능한 $가 더 있는지 확인

```c
bool	is_alpha(char c)
bool	is_digit(char c)
```
- libft로 옮겨야하나 고민...



#64