### PR TITLE
feat: :sparkles: Improve expansion scan with brace

### DIFF
--- a/include/lexer.h
+++ b/include/lexer.h
@@ -59,6 +59,7 @@ void		scan_node_print(void *param);
 ** < scanner_util.c > */
 
 bool		is_quotes_open(char *last_quote, char *str);
+bool		is_brace_open(char *str);
 t_res		buf_to_list(t_list **list, char **buf);
 t_res		whitespace_scan(t_list **list, char **buf, char *str, int *idx);
 /*

--- a/src/lexer/scanner.c
+++ b/src/lexer/scanner.c
@@ -22,8 +22,11 @@ static t_res	scanner_loop(t_list **scan_list, char *line, char **buf, int *i)
 	{
 		if (whitespace_scan(scan_list, buf, line, i) == OK)
 			continue ;
-		if (dollar_scan(scan_list, buf, line, i) == OK)
+		scan_res = dollar_scan(scan_list, buf, line, i);
+		if (scan_res == OK)
 			continue ;
+		if (scan_res == ERR)
+			return (free_n_return(buf, ERR));
 		scan_res = metachar_scan(scan_list, buf, line, i);
 		if (scan_res == OK)
 			continue ;

--- a/src/lexer/scanner_util.c
+++ b/src/lexer/scanner_util.c
@@ -25,6 +25,26 @@ bool	is_quotes_open(char *last_quote, char *str)
 	return (open);
 }
 
+bool	is_brace_open(char *str)
+{
+	int		i;
+	bool	open;
+
+	i = -1;
+	open = false;
+	while (str[++i])
+	{
+		if (str[i] == '$' && str[i + 1] == '{')
+		{
+			open = true;
+			i++;
+		}
+		if (open && str[i] == '}')
+			open = false;
+	}
+	return (open);
+}
+
 t_res	buf_to_list(t_list **list, char **buf)
 {
 	const int	buf_len = ft_strlen(*buf);

--- a/src/lexer/scanner_util3.c
+++ b/src/lexer/scanner_util3.c
@@ -1,11 +1,13 @@
 #include "minishell.h"
 
-static t_res	expansions_update(t_expansion_scan_info *info, int end)
+static t_res	expansions_update_with_brace(
+	t_expansion_scan_info *info, int end, bool brace)
 {
 	char	*parameter;
 
 	info->end = end - *info->idx + info->start_i;
-	parameter = new_str_slice(*info->buf, info->begin + 1, info->end + 1);
+	parameter = new_str_slice(*info->buf,
+			info->begin + 1 + brace, info->end + 1 - brace);
 	expansions_append_free(&info->expansions,
 		new_ast_expansion(parameter, info->begin, info->end));
 	free(parameter);
@@ -24,18 +26,28 @@ static t_res	expansion_scan_loop(t_expansion_scan_info *info, int *i)
 {
 	while (is_scan_continuos(*info->buf, info->str[++*i]))
 	{
-		if (!is_variable_char_valid(info->str[*i]))
+		if (!is_brace_open(*info->buf)
+			&& !is_variable_char_valid(info->str[*i]))
 		{
 			if (info->end < info->begin)
-				expansions_update(info, *i - 1);
+				expansions_update_with_brace(info, *i - 1, false);
 			if (is_multi_expansions(*info, *i)
 				&& expansion_location_init(info, i) == OK)
 				continue ;
 		}
+		if (info->str[*i] == '}' && info->end < info->begin)
+			expansions_update_with_brace(info, *i, true);
 		ft_str_append(info->buf, info->str[*i]);
 	}
+	if (is_brace_open(*info->buf))
+	{
+		printf(BRED "minishell: unclosed brace: ");
+		printf("multiline is not supported :(\n" END);
+		del_ast_expansions(info->expansions);
+		return (ERR);
+	}
 	if (info->end < info->begin)
-		expansions_update(info, *i - 1);
+		expansions_update_with_brace(info, *i - 1, false);
 	return (OK);
 }
 
@@ -47,13 +59,14 @@ t_res	expansion_scan(t_list **list, char **buf, char *str, int *idx)
 	info.buf = buf;
 	info.str = str;
 	info.idx = idx;
-	info.expansions = new_ast_expansions((t_AST_expansion *[]){NULL});
 	info.start_i = ft_strlen(*buf);
 	i = *info.idx;
 	if (!is_1stchar_valid(str[i + 1]))
 		return (UNSET);
+	info.expansions = new_ast_expansions((t_AST_expansion *[]){NULL});
 	expansion_location_init(&info, &i);
-	expansion_scan_loop(&info, &i);
+	if (expansion_scan_loop(&info, &i) == ERR)
+		return (ERR);
 	ft_list_append(list, new_list(
 			new_scan_node(new_str(*info.buf), info.expansions)));
 	*idx = --i;
@@ -74,6 +87,8 @@ t_res	dollar_scan(t_list **list, char **buf, char *str, int *idx)
 		res = expansion_scan(list, buf, str, &i);
 		if (res == UNSET)
 			return (UNSET);
+		if (res == ERR)
+			return (ERR);
 		*idx = i;
 		free(*buf);
 		*buf = new_str("");

--- a/src/lexer/util2.c
+++ b/src/lexer/util2.c
@@ -2,21 +2,21 @@
 
 bool	is_1stchar_valid(char c)
 {
-	if (is_alpha(c) || c == '{' || c == '_')
+	if (is_alpha(c) || c == '_' || c == '{')
 		return (true);
 	return (false);
 }
 
 bool	is_variable_char_valid(char c)
 {
-	if (is_alpha(c) || is_digit(c) || c == '_' || c == '}')
+	if (is_alpha(c) || is_digit(c) || c == '_')
 		return (true);
 	return (false);
 }
 
 bool	is_scan_continuos(char *buf, char c)
 {
-	if (!c || (!is_quotes_open(NULL, buf)
+	if (!c || (!is_quotes_open(NULL, buf) && !is_brace_open(buf)
 			&& (is_whitespace(c) || is_metachar(c))))
 		return (false);
 	return (true);
@@ -27,7 +27,8 @@ bool	is_multi_expansions(t_expansion_scan_info info, int i)
 	char	last_quote;
 
 	if (info.str[i] == '$' && is_1stchar_valid(info.str[i + 1])
-		&& (!is_quotes_open(&last_quote, *info.buf) || last_quote != '\''))
+		&& (!is_quotes_open(&last_quote, *info.buf) || last_quote != '\'')
+		&& !is_brace_open(*info.buf))
 		return (true);
 	return (false);
 }


### PR DESCRIPTION
### 개요
$뒤에 중괄호{}가 오는 경우 처리하기
- {}는 무조건 최초의 한 쌍에 대해서만 기능을 인정
- {}안에 오는 특수기호는 전부 일반 문자로 처리

### 구현
```c
bool	is_brace_open(char *str);
```
- 반드시 ${로 시작해서 처음 만나는 }에 의해서 close

```c
static t_res	expansions_update_with_brace(
	t_expansion_scan_info *info, int end, bool brace);
```
- 기존 expansions_update 함수에 {}가 있을 때 slice하는 index 조절

closes #64