### PR TITLE
feat: :sparkles: Add parser

### DIFF
--- a/include/ast_type.h
+++ b/include/ast_type.h
@@ -46,6 +46,7 @@ typedef struct s_AST_COMMAND
 typedef struct s_AST_PIPELINE
 {
 	t_AST_COMMAND	**commands;
+	int				commands_len;
 }	t_AST_PIPELINE;
 
 typedef	t_res(t_nodefunc_f)(t_AST_NODE *node);

--- a/include/parser.h
+++ b/include/parser.h
@@ -1,11 +1,21 @@
 #ifndef PARSER_H
 # define PARSER_H
+
+typedef struct s_command_data
+{
+	int	name_index;
+	int	num_prefix;
+	int	num_suffix;
+}	t_command_data;
+
 //@func
 /*
 ** < del.c > */
 
 void			del_ast_expansions(t_AST_expansion *expansions[]);
 void			del_ast_node(t_AST_NODE *node);
+void			del_ast_command(t_AST_COMMAND *command);
+void			del_ast_pipeline(t_AST_PIPELINE *pipeline);
 /*
 ** < new1.c > */
 
@@ -15,10 +25,22 @@ t_AST_NODE		*new_ast_word( const char *text,
 					t_AST_expansion *expansions[]);
 t_AST_NODE		*new_ast_redirect( const char *text,
 					t_AST_expansion *expansions[], t_redirect_op op);
-t_AST_COMMAND	*new_ast_command( t_AST_NODE *name, t_AST_NODE *prefixes[],
-					t_AST_NODE *suffixes[]);
 /*
 ** < new2.c > */
 
-t_AST_PIPELINE	*new_ast_pipeline(t_AST_COMMAND *commands[]);
+t_AST_COMMAND	*new_command(t_token tokens[], t_command_data data);
+t_AST_PIPELINE	*new_ast_pipeline(t_AST_COMMAND *commands[],
+					int commands_len);
+/*
+** < parser.c > */
+
+t_AST_PIPELINE	*parser(t_token tokens[]);
+/*
+** < util.c > */
+
+t_redirect_op	redirection_option(char *str);
+int				tokens_n_pipeline_count(int *size, t_token tokens[]);
+int				commands_size(int pipe_count);
+void			command_data_init(t_command_data *data, t_token tokens[],
+					int begin, int end);
 #endif

--- a/makefile
+++ b/makefile
@@ -21,7 +21,7 @@ PKGS     := prompt lexer parser api builtin tree
 
 lexerV   := lexer scanner expansion tokenizer util util2 \
 			scanner_list scanner_util scanner_util2 scanner_util3
-parserV  := new1 new2 del
+parserV  := parser new1 new2 del util
 promptV  := prompt interrupt util
 apiV     := exec pipe signal path file redirect util
 builtinV := env util

--- a/src/parser/del.c
+++ b/src/parser/del.c
@@ -22,3 +22,36 @@ void	del_ast_node(t_AST_NODE *node)
 		del_ast_expansions(node->expansions);
 	free(node);
 }
+
+void	del_ast_command(t_AST_COMMAND *command)
+{
+	int	i;
+
+	del_ast_node(command->name);
+	i = -1;
+	if (command->prefixes)
+	{
+		while (command->prefixes[++i])
+			del_ast_node(command->prefixes[i]);
+		free(command->prefixes);
+	}
+	i = -1;
+	if (command->suffixes)
+	{
+		while (command->suffixes[++i])
+			del_ast_node(command->suffixes[i]);
+		free(command->suffixes);
+	}
+	free(command);
+}
+
+void	del_ast_pipeline(t_AST_PIPELINE *pipeline)
+{
+	int			i;
+
+	i = -1;
+	while (pipeline->commands[++i])
+		del_ast_command(pipeline->commands[i]);
+	free(pipeline->commands);
+	free(pipeline);
+}

--- a/src/parser/new1.c
+++ b/src/parser/new1.c
@@ -41,7 +41,10 @@ t_AST_NODE	*new_ast_word(
 	node->op = NOT_REDIR;
 	node->type = WORD;
 	node->text = new_str(text);
-	node->expansions = expansions;
+	if (expansions)
+		node->expansions = new_ast_expansions(expansions);
+	else
+		node->expansions = NULL;
 	return (node);
 }
 
@@ -58,16 +61,16 @@ t_AST_NODE	*new_ast_redirect(
 	return (node);
 }
 
-t_AST_COMMAND	*new_ast_command(
-	t_AST_NODE *name, t_AST_NODE *prefixes[], t_AST_NODE *suffixes[])
-{
-	t_AST_COMMAND	*new;
+// t_AST_COMMAND	*new_ast_command(
+// 	t_AST_NODE *name, t_AST_NODE *prefixes[], t_AST_NODE *suffixes[])
+// {
+// 	t_AST_COMMAND	*new;
 
-	new = malloc(sizeof(t_AST_COMMAND));
-	if (!new)
-		return (NULL);
-	new->name = name;
-	new->prefixes = prefixes;
-	new->suffixes = suffixes;
-	return (new);
-}
+// 	new = malloc(sizeof(t_AST_COMMAND));
+// 	if (!new)
+// 		return (NULL);
+// 	new->name = name;
+// 	new->prefixes = prefixes;
+// 	new->suffixes = suffixes;
+// 	return (new);
+// }

--- a/src/parser/new2.c
+++ b/src/parser/new2.c
@@ -1,6 +1,34 @@
 #include "minishell.h"
 
-t_AST_PIPELINE	*new_ast_pipeline(t_AST_COMMAND *commands[])
+static t_AST_NODE	**new_prefixes_n_suffixes(int size)
+{
+	t_AST_NODE	**new;
+
+	if (size)
+		new = ft_calloc(sizeof(t_AST_NODE *), size);
+	if (!size || !new)
+		return (NULL);
+	return (new);
+}
+
+t_AST_COMMAND	*new_command(t_token tokens[], t_command_data data)
+{
+	t_AST_COMMAND	*new;
+
+	new = malloc(sizeof(t_AST_COMMAND));
+	if (!new)
+		return (NULL);
+	if (data.name_index == -1)
+		new->name = new_ast_word("", NULL);
+	else
+		new->name = new_ast_word(tokens[data.name_index].text,
+				tokens[data.name_index].expansions);
+	new->prefixes = new_prefixes_n_suffixes(data.num_prefix);
+	new->suffixes = new_prefixes_n_suffixes(data.num_suffix);
+	return (new);
+}
+
+t_AST_PIPELINE	*new_ast_pipeline(t_AST_COMMAND *commands[], int commands_len)
 {
 	t_AST_PIPELINE	*pipeline;
 
@@ -8,5 +36,6 @@ t_AST_PIPELINE	*new_ast_pipeline(t_AST_COMMAND *commands[])
 	if (!pipeline)
 		return (NULL);
 	pipeline->commands = commands;
+	pipeline->commands_len = commands_len;
 	return (pipeline);
 }

--- a/src/parser/parser.c
+++ b/src/parser/parser.c
@@ -1,0 +1,102 @@
+#include "minishell.h"
+
+static t_res	prefixes_parsing(
+	t_AST_COMMAND *command, t_token tokens[], int *prefix_i, int *i)
+{
+	const t_redirect_op	op = redirection_option(tokens[*i].text);
+
+	command->prefixes[*prefix_i] = new_ast_redirect(
+			tokens[*i + 1].text, tokens[*i + 1].expansions, op);
+	*i += 1;
+	if (!command->prefixes[(*prefix_i)++])
+		return (ERR);
+	return (OK);
+}
+
+static t_res	suffixes_parsing(
+	t_AST_COMMAND *command, t_token tokens[], int *suffix_i, int *i)
+{
+	const t_redirect_op	op = redirection_option(tokens[*i].text);
+
+	if (op == NOT_REDIR)
+		command->suffixes[*suffix_i] = new_ast_word(
+				tokens[*i].text, tokens[*i].expansions);
+	else
+		command->suffixes[*suffix_i] = new_ast_redirect(
+				tokens[*i + 1].text, tokens[*i + 1].expansions, op);
+	*i += (op != NOT_REDIR);
+	if (!command->suffixes[(*suffix_i)++])
+		return (ERR);
+	return (OK);
+}
+
+static t_AST_COMMAND	*command_parsing(t_token tokens[], int begin, int end)
+{
+	t_command_data	data;
+	t_AST_COMMAND	*command;
+	int				i;
+	int				prefix_i;
+	int				suffix_i;
+
+	command_data_init(&data, tokens, begin, end);
+	command = new_command(tokens, data);
+	i = begin - 1;
+	prefix_i = 0;
+	suffix_i = 0;
+	while (++i < end)
+	{
+		if (data.name_index == -1 || i < data.name_index)
+			prefixes_parsing(command, tokens, &prefix_i, &i);
+		if (i == data.name_index)
+			continue ;
+		if (data.name_index != -1 && i > data.name_index)
+			suffixes_parsing(command, tokens, &suffix_i, &i);
+	}
+	return (command);
+}
+
+static t_res	command_parsing_with_pipe(
+	t_AST_COMMAND *commands[], t_token tokens[])
+{
+	int	i;
+	int	begin;
+	int	command_i;
+
+	i = -1;
+	begin = 0;
+	command_i = 0;
+	while (tokens[++i].text)
+	{
+		if (tokens[i].type == PIPELINE)
+		{
+			commands[command_i] = command_parsing(tokens, begin, i);
+			command_i++;
+			begin = i + 1;
+		}
+	}
+	commands[command_i] = command_parsing(tokens, begin, i);
+	return (OK);
+}
+
+t_AST_PIPELINE	*parser(t_token tokens[])
+{
+	int				tokens_size;
+	const int		pipe_count = tokens_n_pipeline_count(&tokens_size, tokens);
+	const int		commands_len = commands_size(pipe_count);
+	t_AST_PIPELINE	*pipeline;
+	t_AST_COMMAND	**commands;
+
+	commands = ft_calloc(sizeof(t_AST_COMMAND *), commands_len);
+	if (!commands)
+	{
+		del_tokens(tokens);
+		return (NULL);
+	}
+	if (!pipe_count)
+		commands[0] = command_parsing(tokens, 0, tokens_size);
+	else
+		command_parsing_with_pipe(commands, tokens);
+	pipeline = new_ast_pipeline(commands, commands_len);
+	del_tokens(tokens);
+	return (pipeline);
+}

--- a/src/parser/util.c
+++ b/src/parser/util.c
@@ -1,0 +1,71 @@
+#include "minishell.h"
+
+t_redirect_op	redirection_option(char *str)
+{
+	if (is_str_equal(str, "<"))
+		return (REDIR_INPUT);
+	if (is_str_equal(str, "<<"))
+		return (REDIR_HEREDOC);
+	if (is_str_equal(str, ">"))
+		return (REDIR_OUTPUT);
+	if (is_str_equal(str, ">>"))
+		return (REDIR_OUTPUT_APPEND);
+	return (NOT_REDIR);
+}
+
+int	tokens_n_pipeline_count(int *size, t_token tokens[])
+{
+	int	i;
+	int	count;
+	int	len;
+
+	count = 0;
+	len = 0;
+	i = -1;
+	while (tokens[++i].text)
+	{
+		if (tokens[i].type == PIPELINE)
+			count++;
+		len++;
+	}
+	*size = len;
+	return (count);
+}
+
+int	commands_size(int pipe_count)
+{
+	if (pipe_count)
+		return (pipe_count + 1);
+	else
+		return (1);
+}
+
+void	command_data_init(
+	t_command_data *data, t_token tokens[], int begin, int end)
+{
+	int	i;
+
+	data->name_index = -1;
+	data->num_prefix = 0;
+	data->num_suffix = 0;
+	i = begin - 1;
+	while (++i < end)
+	{
+		if (tokens[i].type == REDIRECT)
+		{
+			if (data->name_index == -1)
+				data->num_prefix++;
+			else
+				data->num_suffix++;
+			i++;
+			continue ;
+		}
+		if (tokens[i].type == WORD)
+		{
+			if (data->name_index == -1)
+				data->name_index = i;
+			else
+				data->num_suffix++;
+		}
+	}
+}

--- a/src/prompt/prompt.c
+++ b/src/prompt/prompt.c
@@ -29,14 +29,18 @@ static void	del_prompt(t_prompt *prompt)
 
 static void	prompt_run_line(char *line)
 {
-	t_token	*tokens;
+	t_token			*tokens;
+	t_AST_PIPELINE	*pipeline;
 
 	tokens = lexer(line);
 	if (tokens)
 	{
-		tokens_print(tokens);
-		printf(GRNB BWHT "GO PARSER" END "\n");
-		del_tokens(tokens);
+		pipeline = parser(tokens);
+		if (pipeline)
+		{
+			ast_pipeline_repr(pipeline, 0);
+			del_ast_pipeline(pipeline);
+		}
 	}
 	free(line);
 }

--- a/src/tree/repr2.c
+++ b/src/tree/repr2.c
@@ -35,6 +35,11 @@ void	ast_pipeline_repr(t_AST_PIPELINE *pipeline, int level)
 	int			i;
 	const int	indent = level * INDENT_SIZE;
 
+	if (pipeline->commands_len == 1)
+	{
+		ast_command_repr(pipeline->commands[0], indent);
+		return ;
+	}
 	printf(BBLU "%*s🔗PIPELINE\n" END, indent, "");
 	if (pipeline->commands)
 	{


### PR DESCRIPTION
### 개요
parser 구현 및 AST 함수 수정
- print 함수 수정, del 함수 추가

### API
```c
typedef struct s_AST_PIPELINE
{
	t_AST_COMMAND	**commands;
	int				commands_len;
}	t_AST_PIPELINE;

t_AST_PIPELINE	*parser(t_token tokens[]);
```
- pipeline이 없는 command는 pipeline 안의 길이가 1인 commands 배열로 약속
- 판별하기 수월하게 구조체에 commands_len을 추가
- commans 배열을 먼저 parsing하고 pipeline에 붙여주는 방식으로 구현

### 구현
```c
int	tokens_n_pipeline_count(int *size, t_token tokens[]);
int	commands_size(int pipe_count);
```
1. tokens 한 번 돌면서 전체 개수와 pipeline의 개수를 반환하는 함수
2. pipeline의 개수에 따라 생성될 commands의 개수를 반환하는 함수

```c
static t_res	command_parsing_with_pipe(t_AST_COMMAND *commands[], t_token tokens[]);
static t_AST_COMMAND	*command_parsing(t_token tokens[], int begin, int end);
```
- commands의 개수와 상관없이 command_parsing을 이용할 수 있도록 begin과 end를 도입
- lexer에서 token의 유효성을 검사했기때문에, 규칙에 맞게 prefix, name, suffix를 parsing

### 사용법
```c
static void	prompt_run_line(char *line)
{
	t_token			*tokens;
	t_AST_PIPELINE	*pipeline;

	tokens = lexer(line);
	if (tokens)
	{
		pipeline = parser(tokens);
		if (pipeline)
		{
			ast_pipeline_repr(pipeline, 0);
                        // 여기에서 pipeline을 받아서 사용
			del_ast_pipeline(pipeline);
		}
	}
	free(line);
}
```
![image](https://user-images.githubusercontent.com/76509884/154985762-2a95d852-5dab-4bd1-9e4e-000b3cad6fd4.png)


closes #67