### PR TITLE
feat: :sparkles: Add expander() -> word expansion functions

### DIFF
--- a/include/lexer.h
+++ b/include/lexer.h
@@ -69,9 +69,9 @@ t_res		dollar_scan(t_list **list, char **buf, char *str, int *idx);
 /*
 ** < tokenizer.c > */
 
-t_AST_type	tokentype_check(t_scan_node *node);
 void		tokens_print(t_token tokens[]);
 void		del_tokens(t_token tokens[]);
+char		*new_quotes_remove(const char *str);
 t_token		*tokenizer(t_list *scan_list);
 /*
 ** < util.c > */

--- a/include/parser.h
+++ b/include/parser.h
@@ -17,6 +17,10 @@ void			del_ast_node(t_AST_NODE *node);
 void			del_ast_command(t_AST_COMMAND *command);
 void			del_ast_pipeline(t_AST_PIPELINE *pipeline);
 /*
+** < expander.c > */
+
+t_res			expander(t_AST_PIPELINE *pipeline, t_dict *env);
+/*
 ** < new1.c > */
 
 t_AST_expansion	*new_ast_expansion(char *parameter, int begin, int end);
@@ -34,13 +38,13 @@ t_AST_PIPELINE	*new_ast_pipeline(t_AST_COMMAND *commands[],
 /*
 ** < parser.c > */
 
-t_AST_PIPELINE	*parser(t_token tokens[]);
+t_AST_PIPELINE	*parser(t_token tokens[], t_dict *env);
 /*
 ** < util.c > */
 
 t_redirect_op	redirection_option(char *str);
 int				tokens_n_pipeline_count(int *size, t_token tokens[]);
 int				commands_size(int pipe_count);
-void			command_data_init(t_command_data *data, t_token tokens[],
+void			command_data_init( t_command_data *data, t_token tokens[],
 					int begin, int end);
 #endif

--- a/include/parser.h
+++ b/include/parser.h
@@ -32,7 +32,7 @@ t_AST_NODE		*new_ast_redirect( const char *text,
 /*
 ** < new2.c > */
 
-t_AST_COMMAND	*new_command(t_token tokens[], t_command_data data);
+t_AST_COMMAND	*new_ast_command(t_token tokens[], t_command_data data);
 t_AST_PIPELINE	*new_ast_pipeline(t_AST_COMMAND *commands[],
 					int commands_len);
 /*

--- a/include/prompt.h
+++ b/include/prompt.h
@@ -20,7 +20,7 @@ void	prompt_new_line(int status);
 /*
 ** < prompt.c > */
 
-void	prompt(void);
+void	prompt(t_dict *env);
 /*
 ** < util.c > */
 

--- a/makefile
+++ b/makefile
@@ -21,7 +21,7 @@ PKGS     := prompt lexer parser api builtin tree
 
 lexerV   := lexer scanner expansion tokenizer util util2 \
 			scanner_list scanner_util scanner_util2 scanner_util3
-parserV  := parser new1 new2 del util
+parserV  := parser new1 new2 del util expander
 promptV  := prompt interrupt util
 apiV     := exec pipe signal path file redirect util
 builtinV := env util

--- a/src/lexer/tokenizer.c
+++ b/src/lexer/tokenizer.c
@@ -1,6 +1,6 @@
 #include "minishell.h"
 
-t_AST_type	tokentype_check(t_scan_node *node)
+static t_AST_type	tokentype_check(t_scan_node *node)
 {
 	const char	*str = node->text;
 
@@ -42,7 +42,7 @@ void	del_tokens(t_token tokens[])
 	free(tokens);
 }
 
-static char	*new_quotes_remove(const char *str)
+char	*new_quotes_remove(const char *str)
 {
 	char	*new;
 	int		i;

--- a/src/main.c
+++ b/src/main.c
@@ -1,6 +1,13 @@
 #include "minishell.h"
 
-int	main(void)
+int	main(int argc, char *argv[], char *envp[])
 {
+	t_dict	*env;
+
+	(void)argc;
+	(void)argv;
+	env = new_env(envp);
+	prompt(env);
+	del_dict(env);
 	return (0);
 }

--- a/src/parser/expander.c
+++ b/src/parser/expander.c
@@ -48,7 +48,12 @@ static t_res	node_expansion(t_AST_NODE *node, t_dict *env)
 {
 	char	**text_split;
 
-	if (!node->expansions[0])
+	if (node->op == REDIR_HEREDOC)
+	{
+		del_ast_expansions(node->expansions);
+		node->expansions = NULL;
+	}
+	if (!node->expansions || !node->expansions[0])
 		return (UNSET);
 	text_split = new_arr((char *[]){NULL});
 	expansions_to_array(&text_split, node);

--- a/src/parser/expander.c
+++ b/src/parser/expander.c
@@ -1,0 +1,87 @@
+#include "minishell.h"
+
+static t_res	word_expansion(char **parr[], t_AST_NODE *node, t_dict *env)
+{
+	int		i;
+	char	*temp_str;
+
+	i = -1;
+	while ((*parr)[++i])
+	{
+		if (i % 2)
+			ft_str_replace(&(*parr)[i],
+				new_str(env_get(env, node->expansions[i >> 1]->parameter)));
+	}
+	temp_str = new_str_join(*parr, '\0');
+	ft_str_replace(&node->text, new_quotes_remove(temp_str));
+	del_ast_expansions(node->expansions);
+	node->expansions = NULL;
+	del_arr(*parr);
+	free(temp_str);
+	return (OK);
+}
+
+static t_res	expansions_to_array(char **parr[], t_AST_NODE *node)
+{
+	const int	len = ft_strlen(node->text);
+	int			i;
+	int			begin;
+	char		*buf;
+
+	i = -1;
+	begin = 0;
+	while (node->expansions[++i])
+	{
+		buf = new_str_slice(node->text, begin, node->expansions[i]->begin);
+		ft_arr_append_free(parr, buf);
+		buf = new_str_slice(node->text,
+				node->expansions[i]->begin, node->expansions[i]->end + 1);
+		ft_arr_append_free(parr, buf);
+		begin = node->expansions[i]->end + 1;
+	}
+	buf = new_str_slice(node->text, begin, len);
+	ft_arr_append_free(parr, buf);
+	return (OK);
+}
+
+static t_res	node_expansion(t_AST_NODE *node, t_dict *env)
+{
+	char	**text_split;
+
+	if (!node->expansions[0])
+		return (UNSET);
+	text_split = new_arr((char *[]){NULL});
+	expansions_to_array(&text_split, node);
+	word_expansion(&text_split, node, env);
+	return (OK);
+}
+
+static t_res	commands_expansion(t_AST_COMMAND *command, t_dict *env)
+{
+	int	i;
+
+	node_expansion(command->name, env);
+	i = -1;
+	if (command->prefixes)
+	{
+		while (command->prefixes[++i])
+			node_expansion(command->prefixes[i], env);
+	}
+	i = -1;
+	if (command->suffixes)
+	{
+		while (command->suffixes[++i])
+			node_expansion(command->suffixes[i], env);
+	}
+	return (OK);
+}
+
+t_res	expander(t_AST_PIPELINE *pipeline, t_dict *env)
+{
+	int		i;
+
+	i = -1;
+	while (pipeline->commands[++i])
+		commands_expansion(pipeline->commands[i], env);
+	return (OK);
+}

--- a/src/parser/new2.c
+++ b/src/parser/new2.c
@@ -11,7 +11,7 @@ static t_AST_NODE	**new_prefixes_n_suffixes(int size)
 	return (new);
 }
 
-t_AST_COMMAND	*new_command(t_token tokens[], t_command_data data)
+t_AST_COMMAND	*new_ast_command(t_token tokens[], t_command_data data)
 {
 	t_AST_COMMAND	*new;
 

--- a/src/parser/parser.c
+++ b/src/parser/parser.c
@@ -78,7 +78,7 @@ static t_res	command_parsing_with_pipe(
 	return (OK);
 }
 
-t_AST_PIPELINE	*parser(t_token tokens[])
+t_AST_PIPELINE	*parser(t_token tokens[], t_dict *env)
 {
 	int				tokens_size;
 	const int		pipe_count = tokens_n_pipeline_count(&tokens_size, tokens);
@@ -97,6 +97,7 @@ t_AST_PIPELINE	*parser(t_token tokens[])
 	else
 		command_parsing_with_pipe(commands, tokens);
 	pipeline = new_ast_pipeline(commands, commands_len);
+	expander(pipeline, env);
 	del_tokens(tokens);
 	return (pipeline);
 }

--- a/src/parser/parser.c
+++ b/src/parser/parser.c
@@ -39,7 +39,7 @@ static t_AST_COMMAND	*command_parsing(t_token tokens[], int begin, int end)
 	int				suffix_i;
 
 	command_data_init(&data, tokens, begin, end);
-	command = new_command(tokens, data);
+	command = new_ast_command(tokens, data);
 	i = begin - 1;
 	prefix_i = 0;
 	suffix_i = 0;

--- a/src/prompt/prompt.c
+++ b/src/prompt/prompt.c
@@ -27,7 +27,7 @@ static void	del_prompt(t_prompt *prompt)
 	free(prompt->ps2);
 }
 
-static void	prompt_run_line(char *line)
+static void	prompt_run_line(char *line, t_dict *env)
 {
 	t_token			*tokens;
 	t_AST_PIPELINE	*pipeline;
@@ -35,7 +35,7 @@ static void	prompt_run_line(char *line)
 	tokens = lexer(line);
 	if (tokens)
 	{
-		pipeline = parser(tokens);
+		pipeline = parser(tokens, env);
 		if (pipeline)
 		{
 			ast_pipeline_repr(pipeline, 0);
@@ -45,7 +45,7 @@ static void	prompt_run_line(char *line)
 	free(line);
 }
 
-static void	prompt_loop(t_prompt *prompt)
+static void	prompt_loop(t_prompt *prompt, t_dict *env)
 {
 	char	*line;
 
@@ -59,16 +59,16 @@ static void	prompt_loop(t_prompt *prompt)
 		else if (!is_line_empty(line))
 		{
 			add_history(line);
-			prompt_run_line(line);
+			prompt_run_line(line, env);
 		}
 	}
 }
 
-void	prompt(void)
+void	prompt(t_dict *env)
 {
 	t_prompt	prompt;
 
 	prompt_init(&prompt);
-	prompt_loop(&prompt);
+	prompt_loop(&prompt, env);
 	del_prompt(&prompt);
 }


### PR DESCRIPTION
### 개요
expansions 배열이 있는 경우 환경변수에서 parameter에 해당하는 값 찾아 치환하는 함수
- AST 생성한 후 바로 치환하도록 parser 내부에 작성 (`;`를 해석하지 않아 env가 초기값 그대로 사용됨)

### API
```c
t_res	expander(t_AST_PIPELINE *pipeline, t_dict *env);
static t_res	commands_expansion(t_AST_COMMAND *command, t_dict *env);
```
1. commands 배열을 돌면서 commands_expansion() 호출
2. name, prefix, suffix 각각에 맞게 node_expansion() 호출

### 구현
```c
static t_res	node_expansion(t_AST_NODE *node, t_dict *env);
```
- node에 expansions이 있으면 expansions기준으로 문자열을 끊어주고, 치환한 뒤 다시 합쳐주는 함수
- 만약 HEREDOC(<<)에 expansions이 있는 경우 그냥 해제해주고 NULL로 취급

```c
static t_res	expansions_to_array(char **parr[], t_AST_NODE *node);
```
- exapnsions의 위치정보를 기준으로 끊어 문자열배열로 만드는 함수
- 치환해야하는 문자열은 모두 홀수번 index에 담겨짐

```c
static t_res	word_expansion(char **parr[], t_AST_NODE *node, t_dict *env);
```
- 홀수번째에 있는 치환할 문자열을 env_get()을 이용해 가져온 문자열로 치환해주는 함수
- 치환된 문자열배열을 다시 join시켜서 node에 담아주고, expansions는 해제해서 NULL로 만들어줌

### 결과
![image](https://user-images.githubusercontent.com/76509884/155076571-4c0f3a61-05ea-44fe-a2db-94a3c34b2b4d.png)
- `USER42`는 없는 변수이므로 빈 문자열로 치환됨

closes #70