### PR TITLE
Shell, Context 기능 추가 && 종료 코드 저장 및 조회

### DIFF
--- a/include/api.h
+++ b/include/api.h
@@ -18,7 +18,6 @@ typedef enum e_exitcode
 	EXIT_FATAL_ERR_CAUSED_BY_SIGNAL = 128,
 }	t_exitcode;
 
-
 //@func
 /*
 ** < file.c > */
@@ -34,9 +33,11 @@ char	**new_names_from_path(char *name, t_dict *env);
 /*
 ** < shell.c > */
 
+void	shell_clear_script(t_shell *shell);
+void	shell_replace_script(t_shell *shell, t_AST_SCRIPT *script);
 void	shell_init(t_shell *shell, char *envp[]);
 void	del_shell(t_shell *shell);
-void	api_exit(t_shell *shell, t_AST_SCRIPT *scripts, int exitcode);
+void	api_exit(t_shell *shell, int exitcode);
 /*
 ** < signal.c > */
 

--- a/include/builtin.h
+++ b/include/builtin.h
@@ -3,13 +3,18 @@
 
 //@func
 /*
-** < env.c > */
+** < env1.c > */
 
+t_dict	*new_env(char *envp[]);
+void	del_env(t_dict *env);
+char	**new_env_to_envp(t_dict *env);
+/*
+** < env2.c > */
+
+void	env_set_exitcode(t_dict *env, int exitcode);
 void	env_set(t_dict *env, char *str);
 char	*env_get(t_dict *env, char *key);
-t_dict	*new_env(char *envp[]);
 void	env_print(t_dict *env);
-char	**new_env_to_envp(t_dict *env);
 /*
 ** < util.c > */
 

--- a/include/exec.h
+++ b/include/exec.h
@@ -7,7 +7,7 @@ typedef struct s_context
 	t_fd	io_output;
 	char	*executable;
 	char	**argv;
-	char	**env;
+	char	**envp;
 }	t_context;
 
 //@func
@@ -15,6 +15,11 @@ typedef struct s_context
 ** < argv.c > */
 
 char	**new_argv_from_cmd(char *executable, t_AST_COMMAND *cmd);
+/*
+** < context.c > */
+
+void	context_init(t_context *context, t_AST_COMMAND *cmd, t_dict *env);
+t_res	context_run_and_free(t_context *context);
 /*
 ** < exec.c > */
 

--- a/include/exec.h
+++ b/include/exec.h
@@ -1,6 +1,15 @@
 #ifndef EXEC_H
 # define EXEC_H
 
+typedef struct s_context
+{
+	t_fd	io_input;
+	t_fd	io_output;
+	char	*executable;
+	char	**argv;
+	char	**env;
+}	t_context;
+
 //@func
 /*
 ** < argv.c > */
@@ -9,8 +18,8 @@ char	**new_argv_from_cmd(char *executable, t_AST_COMMAND *cmd);
 /*
 ** < exec.c > */
 
-void	child_proc_exec(t_AST_SCRIPT *scripts, t_shell *shell);
-int		api_exec_cmd(t_AST_SCRIPT *scripts, t_shell *shell);
+void	child_proc_exec(t_AST_COMMAND *cmd, t_shell *shell);
+int		api_exec_cmd_at(t_shell *shell, int index);
 /*
 ** < redirect.c > */
 

--- a/include/minishell_type.h
+++ b/include/minishell_type.h
@@ -15,7 +15,7 @@ typedef struct s_shell
 {
 	t_dict			*env;
 	t_prompt		prompt;
-	int				exitcode;
+	t_AST_SCRIPT	*script;
 }	t_shell;
 
 #endif

--- a/makefile
+++ b/makefile
@@ -25,7 +25,7 @@ parserV  := parser new1 new2 del util1 util2 expander
 promptV  := prompt interrupt util
 apiV     := shell signal path file
 execV    := context exec pipe redirect argv util
-builtinV := env util
+builtinV := env1 env2 util
 treeV    := repr1 repr2
 
 # ===== Macros =====

--- a/makefile
+++ b/makefile
@@ -24,7 +24,7 @@ lexerV   := lexer scanner expansion tokenizer util util2 \
 parserV  := parser new1 new2 del util1 util2 expander
 promptV  := prompt interrupt util
 apiV     := shell signal path file
-execV    := exec pipe redirect argv util
+execV    := context exec pipe redirect argv util
 builtinV := env util
 treeV    := repr1 repr2
 

--- a/src/api/shell.c
+++ b/src/api/shell.c
@@ -23,7 +23,7 @@ void	shell_init(t_shell *shell, char *envp[])
 
 void	del_shell(t_shell *shell)
 {
-	del_dict(shell->env);
+	del_env(shell->env);
 	del_prompt(&shell->prompt);
 	shell_clear_script(shell);
 }

--- a/src/api/shell.c
+++ b/src/api/shell.c
@@ -1,9 +1,23 @@
 #include "minishell.h"
 
+void	shell_clear_script(t_shell *shell)
+{
+	if (!shell->script)
+		return ;
+	del_ast_script(shell->script);
+	shell->script = NULL;
+}
+
+void	shell_replace_script(t_shell *shell, t_AST_SCRIPT *script)
+{
+	shell_clear_script(shell);
+	shell->script = script;
+}
+
 void	shell_init(t_shell *shell, char *envp[])
 {
 	shell->env = new_env(envp);
-	shell->exitcode = EXIT_SUCCESS;
+	shell->script = NULL;
 	prompt_init(&shell->prompt);
 }
 
@@ -11,13 +25,12 @@ void	del_shell(t_shell *shell)
 {
 	del_dict(shell->env);
 	del_prompt(&shell->prompt);
+	shell_clear_script(shell);
 }
 
 //	frees allocated memory from shell && exits with exitcode
-void	api_exit(t_shell *shell, t_AST_SCRIPT *scripts, int exitcode)
+void	api_exit(t_shell *shell, int exitcode)
 {
 	del_shell(shell);
-	if (scripts)
-		del_ast_script(scripts);
 	exit(exitcode);
 }

--- a/src/builtin/env1.c
+++ b/src/builtin/env1.c
@@ -1,0 +1,41 @@
+#include "minishell.h"
+
+t_dict	*new_env(char *envp[])
+{
+	int		i;
+	t_dict	*env;
+
+	env = new_dict(free);
+	env->exitcode_str = new_itoa(EXIT_SUCCESS);
+	i = -1;
+	while (envp[++i])
+		env_set(env, envp[i]);
+	return (env);
+}
+
+void	del_env(t_dict *env)
+{
+	free(env->exitcode_str);
+	del_dict(env);
+}
+
+char	**new_env_to_envp(t_dict *env)
+{
+	int		i;
+	t_ditem	*item;
+	char	**envp;
+
+	envp = ft_calloc(sizeof(char *), env->size);
+	if (!envp)
+		return (NULL);
+	i = -1;
+	while (++i < env->capacity)
+	{
+		item = env->items[i];
+		if (!item)
+			continue ;
+		envp[item->order] = new_str_join((char *[]){
+				item->key, item->value, NULL}, '=');
+	}
+	return (envp);
+}

--- a/src/builtin/env2.c
+++ b/src/builtin/env2.c
@@ -1,5 +1,10 @@
 #include "minishell.h"
 
+void	env_set_exitcode(t_dict *env, int exitcode)
+{
+	ft_str_replace(&env->exitcode_str, new_itoa(exitcode));
+}
+
 void	env_set(t_dict *env, char *str)
 {
 	int		eq_idx;
@@ -20,17 +25,6 @@ char	*env_get(t_dict *env, char *key)
 	return (dict_get_default(env, key, ""));
 }
 
-t_dict	*new_env(char *envp[])
-{
-	int		i;
-	t_dict	*env;
-
-	i = -1;
-	env = new_dict(free);
-	while (envp[++i])
-		env_set(env, envp[i]);
-	return (env);
-}
 
 void	env_print(t_dict *env)
 {
@@ -49,25 +43,4 @@ void	env_print(t_dict *env)
 			item->key, (char *)item->value);
 	}
 	free(items);
-}
-
-char	**new_env_to_envp(t_dict *env)
-{
-	int		i;
-	t_ditem	*item;
-	char	**envp;
-
-	envp = ft_calloc(sizeof(char *), env->size);
-	if (!envp)
-		return (NULL);
-	i = -1;
-	while (++i < env->capacity)
-	{
-		item = env->items[i];
-		if (!item)
-			continue ;
-		envp[item->order] = new_str_join((char *[]){
-				item->key, item->value, NULL}, '=');
-	}
-	return (envp);
 }

--- a/src/exec/context.c
+++ b/src/exec/context.c
@@ -1,6 +1,19 @@
 #include "minishell.h"
 
-// t_res	context_init(t_shell *shell)
-// {
+void	context_init(t_context *context, t_AST_COMMAND *cmd, t_dict *env)
+{
+	context->executable = new_executable_from_env(cmd->name->text, env);
+	context->argv = new_argv_from_cmd(context->executable, cmd);
+	context->envp = new_env_to_envp(env);
+}
 
-// }
+//	Always return ERR
+t_res	context_run_and_free(t_context *context)
+{
+	if (execve(context->executable, context->argv, context->envp) == OK)
+		return (OK);
+	del_arr(context->envp);
+	del_arr(context->argv);
+	free(context->executable);
+	return (ERR);
+}

--- a/src/exec/context.c
+++ b/src/exec/context.c
@@ -1,0 +1,6 @@
+#include "minishell.h"
+
+// t_res	context_init(t_shell *shell)
+// {
+
+// }

--- a/src/exec/exec.c
+++ b/src/exec/exec.c
@@ -1,13 +1,11 @@
 #include "minishell.h"
 
-void	child_proc_exec(t_AST_SCRIPT *scripts, t_shell *shell)
+void	child_proc_exec(t_AST_COMMAND *cmd, t_shell *shell)
 {
-	t_AST_COMMAND	*cmd;
 	char			**argv;
 	char			**envp;
 	char			*executable;
 
-	cmd = scripts->commands[0];
 	executable = new_executable_from_env(cmd->name->text, shell->env);
 	argv = new_argv_from_cmd(executable, cmd);
 	envp = new_env_to_envp(shell->env);
@@ -16,15 +14,15 @@ void	child_proc_exec(t_AST_SCRIPT *scripts, t_shell *shell)
 	del_arr(envp);
 	del_arr(argv);
 	free(executable);
-	api_exit(shell, scripts, EXIT_FAILURE);
+	api_exit(shell, EXIT_FAILURE);
 }
 
-static void	child_proc(t_AST_SCRIPT *scripts, t_shell *shell)
+static void	child_proc(t_shell *shell, int index)
 {
 	t_AST_COMMAND	*cmd;
 	char			*text;
 
-	cmd = scripts->commands[0];
+	cmd = shell->script->commands[index];
 	text = cmd->name->text;
 	printf(HYEL "HAYO I'm child\n" END);
 	if (is_builtin(text))
@@ -32,45 +30,46 @@ static void	child_proc(t_AST_SCRIPT *scripts, t_shell *shell)
 		// builtins_exec()
 		printf(BRED "%s is builtin, please wait for a bit "
 			"till it's implemented\n" END, text);
-		api_exit(shell, scripts, EXIT_FAILURE);
+		api_exit(shell, EXIT_FAILURE);
 	}
 	if (is_executable_exists(text, shell->env))
-		return ((void)child_proc_exec(scripts, shell));
+		return ((void)child_proc_exec(cmd, shell));
 	else
 	{
 		printf("cannot find executable %s\n", text);
-		api_exit(shell, scripts, EXIT_FAILURE);
+		api_exit(shell, EXIT_FAILURE);
 	}
 }
 
-static int	parent_proc(pid_t pid, t_shell *shell)
+static int	parent_proc(pid_t pid)
 {
 	int	status;
+	int	exitcode;
 
 	printf(HGRN "HAYO I'm Parent process\n" END);
 	waitpid(pid, &status, 0);
-	shell->exitcode = api_handle_status(status);
-	if (shell->exitcode == OK)
+	exitcode = api_handle_status(status);
+	if (exitcode == OK)
 	{
 		printf(BGRN "HAYO child is successfully dead!\n" END);
 		return (OK);
 	}
 	else
 	{
-		printf(BRED "exitcode: %d\n" END, shell->exitcode);
-		return (shell->exitcode);
+		printf(BRED "exitcode: %d\n" END, exitcode);
+		return (exitcode);
 	}
 }
 
-int	api_exec_cmd(t_AST_SCRIPT *scripts, t_shell *shell)
+int	api_exec_cmd_at(t_shell *shell, int index)
 {
 	pid_t	pid;
 
 	pid = fork();
 	if (is_child(pid))
-		child_proc(scripts, shell);
+		child_proc(shell, index);
 	else if (is_parent(pid))
-		return (parent_proc(pid, shell));
+		return (parent_proc(pid));
 	else
 		printf(RED "fork error\n" END);
 	return (OK);

--- a/src/exec/exec.c
+++ b/src/exec/exec.c
@@ -33,7 +33,7 @@ static void	child_proc(t_shell *shell, int index)
 	}
 }
 
-static int	parent_proc(pid_t pid)
+static int	parent_proc(pid_t pid, t_dict *env)
 {
 	int	status;
 	int	exitcode;
@@ -41,6 +41,7 @@ static int	parent_proc(pid_t pid)
 	printf(HGRN "HAYO I'm Parent process\n" END);
 	waitpid(pid, &status, 0);
 	exitcode = api_handle_status(status);
+	env_set_exitcode(env, exitcode);
 	if (exitcode == OK)
 	{
 		printf(BGRN "HAYO child is successfully dead!\n" END);
@@ -61,7 +62,7 @@ int	api_exec_cmd_at(t_shell *shell, int index)
 	if (is_child(pid))
 		child_proc(shell, index);
 	else if (is_parent(pid))
-		return (parent_proc(pid));
+		return (parent_proc(pid, shell->env));
 	else
 		printf(RED "fork error\n" END);
 	return (OK);

--- a/src/exec/exec.c
+++ b/src/exec/exec.c
@@ -2,18 +2,10 @@
 
 void	child_proc_exec(t_AST_COMMAND *cmd, t_shell *shell)
 {
-	char			**argv;
-	char			**envp;
-	char			*executable;
+	t_context	context;
 
-	executable = new_executable_from_env(cmd->name->text, shell->env);
-	argv = new_argv_from_cmd(executable, cmd);
-	envp = new_env_to_envp(shell->env);
-	if (execve(executable, argv, envp) == OK)
-		return ;
-	del_arr(envp);
-	del_arr(argv);
-	free(executable);
+	context_init(&context, cmd, shell->env);
+	context_run_and_free(&context);
 	api_exit(shell, EXIT_FAILURE);
 }
 

--- a/src/parser/del.c
+++ b/src/parser/del.c
@@ -45,6 +45,9 @@ void	del_ast_command(t_AST_COMMAND *command)
 	free(command);
 }
 
+/*	avoid using it alone!
+	should be only called by t_shell methods
+*/
 void	del_ast_script(t_AST_SCRIPT *script)
 {
 	int	i;

--- a/src/prompt/prompt.c
+++ b/src/prompt/prompt.c
@@ -30,19 +30,20 @@ void	del_prompt(t_prompt *prompt)
 static void	prompt_run_line(char *line, t_shell *shell)
 {
 	t_token			*tokens;
-	t_AST_SCRIPT	*scripts;
+	t_AST_SCRIPT	*script;
 
 	tokens = lexer(line);
 	free(line);
 	if (!tokens)
 		return ;
-	scripts = parser(tokens, shell->env);
-	if (!scripts)
+	script = parser(tokens, shell->env);
+	if (!script)
 		return ;
-	ast_script_repr(scripts);
-	if (is_ast_command(scripts))
-		api_exec_cmd(scripts, shell);
-	del_ast_script(scripts);
+	shell_replace_script(shell, script);
+	ast_script_repr(shell->script);
+	if (is_ast_command(shell->script))
+		api_exec_cmd_at(shell, 0);
+	shell_clear_script(shell);
 }
 
 void	shell_prompt(t_shell *shell)

--- a/src/prompt/prompt.c
+++ b/src/prompt/prompt.c
@@ -44,6 +44,7 @@ static void	prompt_run_line(char *line, t_shell *shell)
 	if (is_ast_command(shell->script))
 		api_exec_cmd_at(shell, 0);
 	shell_clear_script(shell);
+	printf("exit status in env: %s\n", env_get(shell->env, "?"));
 }
 
 void	shell_prompt(t_shell *shell)


### PR DESCRIPTION
### 개요
- `t_shell`이 `t_AST_SCRIPT *script`를 저장하도록 변경 
- execve 실행 보조용 구조체 `t_context` (재)추가
- 종료 코드 저장 및 조회

### API

### `builtin/env`
- `void env_set_exitcode(t_dict *env, int exitcode);`
env에 종료코드 저장. 내부에서 문자열로 치환됨

- `*env_get(t_dict *env, char *key);`
`?`을 이용해 종료코드 문자열로 획득

- `void del_env(t_dict *env)`
`env`에 추가된 내장 변수 `exitcode_str`을 할당 해제하기 위한 함수

#### `api/shell`
shell에서 script를 관리하기 위해 함수 추가

- `void shell_clear_script(t_shell *shell);`
`del_ast_script(shell->script);` 래퍼

- `void shell_replace_script(t_shell *shell, t_AST_SCRIPT *script);`
`ft_str_replace`와 같은 역할

#### `exec/context`
```c
typedef struct s_context
{
	t_fd	io_input;  /* 미구현 */
	t_fd	io_output; /* 미구현 */
	char	*executable;
	char	**argv;
	char	**envp;
}	t_context;
```
`execve`용 래퍼

### `exec/exec`
- `int api_exec_cmd_at(t_shell *shell, int index);`
주어진 인덱스의 명령어 실행으로 변경