### PR TITLE
feat: :sparkles: Add expansion exit status ($?)

### DIFF
--- a/src/lexer/dollar_scan2.c
+++ b/src/lexer/dollar_scan2.c
@@ -24,5 +24,8 @@ t_res	expansion_location_init(t_expansion_scan_info *info, int *i)
 	if (ft_str_extend(info->buf, (char []){'$', info->str[++*i], '\0'}) == ERR)
 		return (free_n_return(info->buf, error_msg_return(MALLOC_ERROR_MSG)));
 	info->end = -1;
+	if (info->str[*i] == '?')
+		if (expansions_update_with_brace(info, *i, false) == ERR)
+			return (ERR);
 	return (OK);
 }

--- a/src/lexer/util2.c
+++ b/src/lexer/util2.c
@@ -2,7 +2,7 @@
 
 bool	is_1stchar_valid(char c)
 {
-	if (is_alpha(c) || c == '_' || c == '{')
+	if (is_alpha(c) || c == '_' || c == '{' || c == '?')
 		return (true);
 	return (false);
 }


### PR DESCRIPTION
### 개요
scanner에서 $?를 따로 구분할 수 있도록 코드 수정
- parameter가 ?인 경우, 직전 exitcode 반환 (확인)
- $? 뒤에 오는 문자는 일반 출력 문자로 처리 ($?HOME -> 0HOME)
- ${?}은 $?와 동일

closes #72