### PR TITLE
tokenizer, parser, expander 함수 NULL check 및 norm 처리

### DIFF
--- a/include/error.h
+++ b/include/error.h
@@ -1,25 +1,17 @@
 #ifndef ERROR_H
 # define ERROR_H
 
-# define MINISHELL			BRED"minishell: "
+# define MINISHELL			"minishell: "
 # define SYNTAX_ERROR		"syntax error near unexpected token"
 # define QUOTE_ERROR		"unclosed quote: "
 # define BRACE_ERROR		"unclosed brace: "
 # define MULTILINE_ERROR	"multiline is not supported :(\n"
 # define MALLOC_ERROR		"failed to allocate memory :(\n"
 
-# define MALLOC_ERROR_MSG	(char *[]){MINISHELL, MALLOC_ERROR, END, NULL}
-
-typedef enum e_error_bit
-{
-	E_ONE = 0x1,
-	E_TWO = 0x10,
-	E_THREE = 0x100,
-}	t_error_bit;
-
 //@func
 /*
 ** < error.c > */
 
 t_res	error_msg_return(char *message[]);
+t_res	error_malloc_msg(void);
 #endif

--- a/include/lexer.h
+++ b/include/lexer.h
@@ -44,6 +44,7 @@ t_res		dollar_scan(t_list **list, char **buf, char *str, int *idx);
 t_res		expansions_update_with_brace( t_expansion_scan_info *info, int end,
 				bool brace);
 t_res		expansion_location_init(t_expansion_scan_info *info, int *i);
+bool		is_multi_expansions(t_expansion_scan_info info, int i);
 /*
 ** < expansion.c > */
 
@@ -70,7 +71,6 @@ bool		is_prev_metachar_attachable(char *str);
 /*
 ** < scanner.c > */
 
-t_res		free_n_return(char **str, t_res result);
 t_res		scanner(t_list **scan_list, char *line);
 /*
 ** < scanner_list.c > */
@@ -90,10 +90,17 @@ t_res		whitespace_scan(t_list **list, char **buf, char *str, int *idx);
 /*
 ** < tokenizer.c > */
 
+t_res		quotes_remove_loop(char **new, char *last_quote, bool *open,
+				char c);
+char		*new_quotes_remove(const char *str);
+t_res		node_tokenize(t_token *tokens[], t_scan_node *node, int i);
+t_token		*tokenizer(t_list *scan_list);
+/*
+** < tokenizer_util.c > */
+
+t_AST_type	tokentype_check(t_scan_node *node);
 void		tokens_print(t_token tokens[]);
 void		del_tokens(t_token tokens[]);
-char		*new_quotes_remove(const char *str);
-t_token		*tokenizer(t_list *scan_list);
 /*
 ** < util.c > */
 
@@ -108,6 +115,6 @@ bool		is_digit(char c);
 bool		is_1stchar_valid(char c);
 bool		is_variable_char_valid(char c);
 bool		is_scan_continuos(char *buf, char c);
-bool		is_multi_expansions(t_expansion_scan_info info, int i);
+t_res		free_n_return(char **str, t_res result);
 t_res		free_arr_n_return(char *arr[], t_res result);
 #endif

--- a/include/parser.h
+++ b/include/parser.h
@@ -15,6 +15,7 @@ typedef struct s_command_data
 void			del_ast_expansions(t_AST_expansion *expansions[]);
 void			del_ast_node(t_AST_NODE *node);
 void			del_ast_command(t_AST_COMMAND *command);
+void			del_ast_commands(t_AST_COMMAND *commands[]);
 void			del_ast_script(t_AST_SCRIPT *script);
 /*
 ** < expander.c > */
@@ -38,19 +39,24 @@ t_AST_SCRIPT	*new_ast_script(t_AST_COMMAND *commands[], int commands_len);
 /*
 ** < parser.c > */
 
-t_AST_SCRIPT	*parser(t_token tokens[], t_dict *env);
+t_res			commands_for_parser( t_AST_COMMAND **commands[],
+					t_token tokens[], int *commands_len);
+t_AST_SCRIPT	*parser(t_token tokens[]);
 /*
 ** < util1.c > */
 
 t_redirect_op	redirection_option(char *str);
 int				tokens_n_pipeline_count(int *size, t_token tokens[]);
-int				commands_size(int pipe_count);
 void			command_data_init( t_command_data *data, t_token tokens[],
 					int begin, int end);
+int				ast_nodes_len(t_AST_NODE *nodes[]);
 /*
 ** < util2.c > */
 
 bool			is_ast_pipeline(t_AST_SCRIPT *script);
 bool			is_ast_command(t_AST_SCRIPT *script);
-int				ast_nodes_len(t_AST_NODE *nodes[]);
+t_res			prefixes_parsing( t_AST_COMMAND *command, t_token tokens[],
+					int *prefix_i, int *i);
+t_res			suffixes_parsing( t_AST_COMMAND *command, t_token tokens[],
+					int *suffix_i, int *i);
 #endif

--- a/include/parser.h
+++ b/include/parser.h
@@ -18,10 +18,14 @@ void			del_ast_command(t_AST_COMMAND *command);
 void			del_ast_commands(t_AST_COMMAND *commands[]);
 void			del_ast_script(t_AST_SCRIPT *script);
 /*
-** < expander.c > */
+** < expander1.c > */
 
 t_res			commands_expansion(t_AST_COMMAND *command, t_dict *env);
 t_res			expander(t_AST_SCRIPT *script, t_dict *env);
+/*
+** < expander2.c > */
+
+t_res			expansions_to_array(char **parr[], t_AST_NODE *node);
 /*
 ** < new1.c > */
 

--- a/makefile
+++ b/makefile
@@ -19,9 +19,10 @@ HGEN     := hgen
 # ===== Packages =====
 PKGS     := prompt lexer parser exec api builtin tree error
 
-lexerV   := lexer expansion tokenizer util util2 \
+lexerV   := lexer expansion util util2 \
 			scanner scanner_list scanner_util \
-			dollar_scan1 dollar_scan2 metachar_scan1 metachar_scan2
+			dollar_scan1 dollar_scan2 metachar_scan1 metachar_scan2 \
+			tokenizer tokenizer_util
 parserV  := parser new1 new2 del util1 util2 expander
 promptV  := prompt interrupt util
 apiV     := shell signal path file

--- a/makefile
+++ b/makefile
@@ -23,7 +23,7 @@ lexerV   := lexer expansion util util2 \
 			scanner scanner_list scanner_util \
 			dollar_scan1 dollar_scan2 metachar_scan1 metachar_scan2 \
 			tokenizer tokenizer_util
-parserV  := parser new1 new2 del util1 util2 expander
+parserV  := parser new1 new2 del util1 util2 expander1 expander2
 promptV  := prompt interrupt util
 apiV     := shell signal path file
 execV    := context exec pipe redirect argv util

--- a/src/error/error.c
+++ b/src/error/error.c
@@ -10,3 +10,9 @@ t_res	error_msg_return(char *message[])
 		printf("%s", message[i]);
 	return (ERR);
 }
+
+t_res	error_malloc_msg(void)
+{
+	return (error_msg_return(
+		(char *[]){BRED, MINISHELL, MALLOC_ERROR, END, NULL}));
+}

--- a/src/lexer/dollar_scan1.c
+++ b/src/lexer/dollar_scan1.c
@@ -8,7 +8,7 @@ static t_res	expansion_last_check(t_expansion_scan_info *info, int *i)
 		free(*info->buf);
 		return (error_msg_return(
 				(char *[]){
-					BRED, MINISHELL, BRACE_ERROR, MULTILINE_ERROR, NULL}));
+				BRED, MINISHELL, BRACE_ERROR, MULTILINE_ERROR, NULL}));
 	}
 	if (info->end < info->begin)
 		if (expansions_update_with_brace(info, *i - 1, false) == ERR)

--- a/src/lexer/dollar_scan1.c
+++ b/src/lexer/dollar_scan1.c
@@ -7,7 +7,8 @@ static t_res	expansion_last_check(t_expansion_scan_info *info, int *i)
 		del_ast_expansions(info->expansions);
 		free(*info->buf);
 		return (error_msg_return(
-				(char *[]){MINISHELL, BRACE_ERROR, MULTILINE_ERROR, NULL}));
+				(char *[]){
+					BRED, MINISHELL, BRACE_ERROR, MULTILINE_ERROR, NULL}));
 	}
 	if (info->end < info->begin)
 		if (expansions_update_with_brace(info, *i - 1, false) == ERR)
@@ -21,8 +22,7 @@ static t_res	brace_closed_n_other_check(t_expansion_scan_info *info, int *i)
 		if (expansions_update_with_brace(info, *i, true) == ERR)
 			return (ERR);
 	if (ft_str_append(info->buf, info->str[*i]) == ERR)
-		return (free_n_return(info->buf,
-				error_msg_return(MALLOC_ERROR_MSG)));
+		return (free_n_return(info->buf, error_malloc_msg()));
 	return (OK);
 }
 
@@ -68,7 +68,7 @@ static t_res	expansion_scan(t_list **list, char **buf, char *str, int *idx)
 		return (UNSET);
 	info.expansions = new_ast_expansions((t_AST_expansion *[]){NULL});
 	if (!info.expansions)
-		return (free_n_return(buf, error_msg_return(MALLOC_ERROR_MSG)));
+		return (free_n_return(buf, error_malloc_msg()));
 	if (expansion_location_init(&info, &i) == ERR)
 		return (ERR);
 	if (expansion_scan_loop(&info, &i) == ERR)
@@ -100,7 +100,7 @@ t_res	dollar_scan(t_list **list, char **buf, char *str, int *idx)
 		free(*buf);
 		*buf = new_str("");
 		if (!buf)
-			return (error_msg_return(MALLOC_ERROR_MSG));
+			return (error_malloc_msg());
 		return (OK);
 	}
 	return (UNSET);

--- a/src/lexer/dollar_scan2.c
+++ b/src/lexer/dollar_scan2.c
@@ -29,3 +29,14 @@ t_res	expansion_location_init(t_expansion_scan_info *info, int *i)
 			return (ERR);
 	return (OK);
 }
+
+bool	is_multi_expansions(t_expansion_scan_info info, int i)
+{
+	char	last_quote;
+
+	if (info.str[i] == '$' && is_1stchar_valid(info.str[i + 1])
+		&& (!is_quotes_open(&last_quote, *info.buf) || last_quote != '\'')
+		&& !is_brace_open(*info.buf))
+		return (true);
+	return (false);
+}

--- a/src/lexer/dollar_scan2.c
+++ b/src/lexer/dollar_scan2.c
@@ -9,11 +9,11 @@ t_res	expansions_update_with_brace(
 	parameter = new_str_slice(*info->buf,
 			info->begin + 1 + brace, info->end + 1 - brace);
 	if (!parameter)
-		return (free_n_return(info->buf, error_msg_return(MALLOC_ERROR_MSG)));
+		return (free_n_return(info->buf, error_malloc_msg()));
 	if (expansions_append_free(&info->expansions,
 			new_ast_expansion(parameter, info->begin, info->end)) == ERR)
 		return (free_arr_n_return((char *[]){*info->buf, parameter, NULL},
-			error_msg_return(MALLOC_ERROR_MSG)));
+			error_malloc_msg()));
 	free(parameter);
 	return (OK);
 }
@@ -22,7 +22,7 @@ t_res	expansion_location_init(t_expansion_scan_info *info, int *i)
 {
 	info->begin = *i - *info->idx + info->start_i;
 	if (ft_str_extend(info->buf, (char []){'$', info->str[++*i], '\0'}) == ERR)
-		return (free_n_return(info->buf, error_msg_return(MALLOC_ERROR_MSG)));
+		return (free_n_return(info->buf, error_malloc_msg()));
 	info->end = -1;
 	if (info->str[*i] == '?')
 		if (expansions_update_with_brace(info, *i, false) == ERR)

--- a/src/lexer/lexer.c
+++ b/src/lexer/lexer.c
@@ -88,6 +88,5 @@ t_token	*lexer(char *line)
 			return (NULL);
 		}
 	}
-	free(line);
 	return (tokens);
 }

--- a/src/lexer/lexer.c
+++ b/src/lexer/lexer.c
@@ -12,8 +12,8 @@ static bool	is_pipeline_token_valid(t_AST_type type[])
 	{
 		error_msg_return(
 			(char *[]){
-				BRED, MINISHELL, SYNTAX_ERROR, " `|'\n",
-				MULTILINE_ERROR, END, NULL});
+			BRED, MINISHELL, SYNTAX_ERROR, " `|'\n",
+			MULTILINE_ERROR, END, NULL});
 		return (false);
 	}
 	return (true);
@@ -25,7 +25,7 @@ static bool	is_redirect_token_valid(t_AST_type type[], char *str)
 	{
 		error_msg_return(
 			(char *[]){
-				BRED, MINISHELL, SYNTAX_ERROR, " `", str, "'\n", END, NULL});
+			BRED, MINISHELL, SYNTAX_ERROR, " `", str, "'\n", END, NULL});
 		return (false);
 	}
 	if ((type[0] == REDIRECT && type[1] == TYPE_END)
@@ -33,7 +33,7 @@ static bool	is_redirect_token_valid(t_AST_type type[], char *str)
 	{
 		error_msg_return(
 			(char *[]){
-				BRED, MINISHELL, SYNTAX_ERROR, " `newline'\n", END, NULL});
+			BRED, MINISHELL, SYNTAX_ERROR, " `newline'\n", END, NULL});
 		return (false);
 	}
 	return (true);
@@ -88,5 +88,6 @@ t_token	*lexer(char *line)
 			return (NULL);
 		}
 	}
+	free(line);
 	return (tokens);
 }

--- a/src/lexer/lexer.c
+++ b/src/lexer/lexer.c
@@ -4,13 +4,16 @@ static bool	is_pipeline_token_valid(t_AST_type type[])
 {
 	if (type[1] == PIPELINE && (type[0] != WORD || type[2] == PIPELINE))
 	{
-		printf(BRED "minishell: syntax error near unexpected token `|'\n" END);
+		error_msg_return(
+			(char *[]){BRED, MINISHELL, SYNTAX_ERROR, " `|'\n", END, NULL});
 		return (false);
 	}
 	if (type[1] == PIPELINE && type[2] == TYPE_END)
 	{
-		printf(BRED "minishell: syntax error near unexpected token `|'\n");
-		printf("multiline is not supported :(\n" END);
+		error_msg_return(
+			(char *[]){
+				BRED, MINISHELL, SYNTAX_ERROR, " `|'\n",
+				MULTILINE_ERROR, END, NULL});
 		return (false);
 	}
 	return (true);
@@ -20,15 +23,17 @@ static bool	is_redirect_token_valid(t_AST_type type[], char *str)
 {
 	if (type[1] == REDIRECT && type[0] == REDIRECT)
 	{
-		printf(BRED "minishell: syntax error near unexpected token ");
-		printf("`%s'\n" END, str);
+		error_msg_return(
+			(char *[]){
+				BRED, MINISHELL, SYNTAX_ERROR, " `", str, "'\n", END, NULL});
 		return (false);
 	}
 	if ((type[0] == REDIRECT && type[1] == TYPE_END)
 		|| (type[1] == REDIRECT && type[2] == TYPE_END))
 	{
-		printf(BRED
-			"minishell: syntax error near unexpected token `newline'\n" END);
+		error_msg_return(
+			(char *[]){
+				BRED, MINISHELL, SYNTAX_ERROR, " `newline'\n", END, NULL});
 		return (false);
 	}
 	return (true);
@@ -52,8 +57,6 @@ static bool	is_tokens_valid(t_token tokens[])
 	int			i;
 	t_AST_type	type[3];
 
-	if (!tokens)
-		return (false);
 	i = -1;
 	while (tokens[++i].text)
 	{
@@ -77,6 +80,8 @@ t_token	*lexer(char *line)
 	else
 	{
 		tokens = tokenizer(scan_list);
+		if (!tokens)
+			return (NULL);
 		if (!is_tokens_valid(tokens))
 		{
 			del_tokens(tokens);

--- a/src/lexer/metachar_scan1.c
+++ b/src/lexer/metachar_scan1.c
@@ -17,15 +17,14 @@ static t_res	metastr_append(
 		*prev_pstr = *pstr;
 		*pstr = new_str((char []){c, '\0'});
 		if (!*pstr)
-			return (free_n_return(prev_pstr,
-					error_msg_return(MALLOC_ERROR_MSG)));
+			return (free_n_return(prev_pstr, error_malloc_msg()));
 		return (OK);
 	}
 	else
 	{
-		return (free_arr_n_return((char *[]){*prev_pstr, *pstr, NULL},
-			error_msg_return((char *[]){
-				MINISHELL, SYNTAX_ERROR, " `", *pstr, "'\n", END, NULL})));
+		error_msg_return((char *[]){BRED, MINISHELL, SYNTAX_ERROR,
+			" `", *pstr, "'\n", END, NULL});
+		return (free_arr_n_return((char *[]){*prev_pstr, *pstr, NULL}, ERR));
 	}
 }
 
@@ -79,7 +78,7 @@ t_res	metachar_scan(t_list **list, char **buf, char *str, int *idx)
 		if (buf_to_list(list, buf) == ERR)
 			return (ERR);
 		if (metachar_valid_check(list, str, idx) == ERR)
-			return (ERR);
+			return (free_n_return(buf, ERR));
 		return (OK);
 	}
 	return (UNSET);

--- a/src/lexer/metachar_scan2.c
+++ b/src/lexer/metachar_scan2.c
@@ -5,7 +5,7 @@ t_res	metachar_attachable(char **pstr, char prev_c, char c)
 	if (prev_c != '|' && ft_strlen(*pstr) == 1 && c == prev_c)
 	{
 		if (ft_str_append(pstr, c) == ERR)
-			return (free_n_return(pstr, error_msg_return(MALLOC_ERROR_MSG)));
+			return (free_n_return(pstr, error_malloc_msg()));
 		return (OK);
 	}
 	return (UNSET);
@@ -15,11 +15,10 @@ t_res	metastr_init(t_metastr *metastr, char c)
 {
 	metastr->str = new_str((char []){c, '\0'});
 	if (!metastr->str)
-		return (error_msg_return(MALLOC_ERROR_MSG));
+		return (error_malloc_msg());
 	metastr->prev = new_str("");
 	if (!metastr->prev)
-		return (free_n_return(&metastr->str,
-				error_msg_return(MALLOC_ERROR_MSG)));
+		return (free_n_return(&metastr->str, error_malloc_msg()));
 	return (OK);
 }
 

--- a/src/lexer/scanner.c
+++ b/src/lexer/scanner.c
@@ -6,6 +6,7 @@ static t_res	error_unclosed(char c, char **buf)
 
 	quote_str = (char []){'(', c, ')', ':', ' ', '\0'};
 	return (free_n_return(buf, error_msg_return((char *[]){
+				BRED,
 				MINISHELL,
 				QUOTE_ERROR,
 				quote_str,
@@ -48,7 +49,7 @@ static t_res	scanner_loop(t_list **scan_list, char *line, char **buf, int *i)
 		if (scan_res == ERR)
 			return (ERR);
 		if (ft_str_append(buf, line[*i]) == ERR)
-			return (free_n_return(buf, error_msg_return(MALLOC_ERROR_MSG)));
+			return (free_n_return(buf, error_malloc_msg()));
 	}
 	return (scan_last_check(scan_list, buf));
 }
@@ -60,7 +61,7 @@ t_res	scanner(t_list **scan_list, char *line)
 
 	buf = new_str("");
 	if (!buf)
-		return (error_msg_return(MALLOC_ERROR_MSG));
+		return (error_malloc_msg());
 	i = -1;
 	return (scanner_loop(scan_list, line, &buf, &i));
 }

--- a/src/lexer/scanner.c
+++ b/src/lexer/scanner.c
@@ -1,11 +1,5 @@
 #include "minishell.h"
 
-t_res	free_n_return(char **str, t_res result)
-{
-	free(*str);
-	return (result);
-}
-
 static t_res	error_unclosed(char c, char **buf)
 {
 	char	*quote_str;

--- a/src/lexer/scanner_util.c
+++ b/src/lexer/scanner_util.c
@@ -54,15 +54,15 @@ t_res	list_element_create(
 	*element = NULL;
 	str = new_str(buf);
 	if (!str)
-		return (error_msg_return(MALLOC_ERROR_MSG));
+		return (error_malloc_msg());
 	content = new_scan_node(str, expansions);
 	if (!content)
-		return (free_n_return(&str, error_msg_return(MALLOC_ERROR_MSG)));
+		return (free_n_return(&str, error_malloc_msg()));
 	*element = new_list(content);
 	if (!element)
 	{
 		del_scan_node(content);
-		return (error_msg_return(MALLOC_ERROR_MSG));
+		return (error_malloc_msg());
 	}
 	return (OK);
 }
@@ -80,7 +80,7 @@ t_res	buf_to_list(t_list **list, char **buf)
 	free(*buf);
 	*buf = new_str("");
 	if (!*buf)
-		return (error_msg_return(MALLOC_ERROR_MSG));
+		return (error_malloc_msg());
 	return (OK);
 }
 

--- a/src/lexer/tokenizer.c
+++ b/src/lexer/tokenizer.c
@@ -27,7 +27,10 @@ char	*new_quotes_remove(const char *str)
 
 	new = new_str("");
 	if (!new)
+	{
+		error_malloc_msg();
 		return (NULL);
+	}
 	open = false;
 	i = -1;
 	while (str[++i])

--- a/src/lexer/tokenizer.c
+++ b/src/lexer/tokenizer.c
@@ -1,45 +1,21 @@
 #include "minishell.h"
 
-static t_AST_type	tokentype_check(t_scan_node *node)
+t_res	quotes_remove_loop(char **new, char *last_quote, bool *open, char c)
 {
-	const char	*str = node->text;
-
-	if (is_str_equal(str, "|"))
-		return (PIPELINE);
-	if (is_str_equal(str, "<") || is_str_equal(str, "<<")
-		|| is_str_equal(str, ">") || is_str_equal(str, ">>"))
-		return (REDIRECT);
-	return (WORD);
-}
-
-void	tokens_print(t_token tokens[])
-{
-	int			i;
-	const char	*type_str[] = {
-		BWHT "💬 WORD", BBLU "🔗 PIPELINE",
-		BYEL "🔁 REDIRECT", BRED "🔥 COMMAND"};
-
-	i = -1;
-	while (tokens[++i].text)
+	if (!*open && is_quotechar(c))
 	{
-		printf("[%2d] %-12s" BGRN "\t%s\n" END,
-			i, type_str[tokens[i].type], tokens[i].text);
-		if (tokens[i].expansions)
-			expansions_print(tokens[i].expansions);
+		*open = true;
+		*last_quote = c;
+		return (OK);
 	}
-}
-
-void	del_tokens(t_token tokens[])
-{
-	int	i;
-
-	i = -1;
-	while (tokens[++i].text)
+	if (*open && *last_quote == c)
 	{
-		free(tokens[i].text);
-		del_ast_expansions(tokens[i].expansions);
+		*open = false;
+		return (OK);
 	}
-	free(tokens);
+	if (ft_str_append(new, c) == ERR)
+		return (free_n_return(new, error_msg_return(MALLOC_ERROR_MSG)));
+	return (OK);
 }
 
 char	*new_quotes_remove(const char *str)
@@ -50,24 +26,30 @@ char	*new_quotes_remove(const char *str)
 	bool	open;
 
 	new = new_str("");
+	if (!new)
+		return (NULL);
 	open = false;
 	i = -1;
 	while (str[++i])
 	{
-		if (!open && is_quotechar(str[i]))
-		{
-			open = true;
-			last_quote = str[i];
-			continue ;
-		}
-		if (open && last_quote == str[i])
-		{
-			open = false;
-			continue ;
-		}
-		ft_str_append(&new, str[i]);
+		if (quotes_remove_loop(&new, &last_quote, &open, str[i]) == ERR)
+			return (NULL);
 	}
 	return (new);
+}
+
+t_res	node_tokenize(t_token *tokens[], t_scan_node *node, int i)
+{
+	if (!node->expansions)
+		(*tokens)[i].text = new_quotes_remove(node->text);
+	else
+		(*tokens)[i].text = new_str(node->text);
+	if (!(*tokens)[i].text)
+		return (error_msg_return(MALLOC_ERROR_MSG));
+	(*tokens)[i].expansions = new_ast_expansions(node->expansions);
+	if (!(*tokens)[i].expansions)
+		return (error_msg_return(MALLOC_ERROR_MSG));
+	return (OK);
 }
 
 t_token	*tokenizer(t_list *scan_list)
@@ -87,11 +69,12 @@ t_token	*tokenizer(t_list *scan_list)
 	{
 		node = (t_scan_node *)current->content;
 		tokens[i].type = tokentype_check(node);
-		if (!node->expansions)
-			tokens[i].text = new_quotes_remove(node->text);
-		else
-			tokens[i].text = new_str(node->text);
-		tokens[i].expansions = new_ast_expansions(node->expansions);
+		if (node_tokenize(&tokens, node, i) == ERR)
+		{
+			del_list(&scan_list, del_scan_node);
+			del_tokens(tokens);
+			return (NULL);
+		}
 		current = current->next;
 	}
 	del_list(&scan_list, del_scan_node);

--- a/src/lexer/tokenizer.c
+++ b/src/lexer/tokenizer.c
@@ -14,7 +14,7 @@ t_res	quotes_remove_loop(char **new, char *last_quote, bool *open, char c)
 		return (OK);
 	}
 	if (ft_str_append(new, c) == ERR)
-		return (free_n_return(new, error_msg_return(MALLOC_ERROR_MSG)));
+		return (free_n_return(new, error_malloc_msg()));
 	return (OK);
 }
 
@@ -45,10 +45,10 @@ t_res	node_tokenize(t_token *tokens[], t_scan_node *node, int i)
 	else
 		(*tokens)[i].text = new_str(node->text);
 	if (!(*tokens)[i].text)
-		return (error_msg_return(MALLOC_ERROR_MSG));
+		return (error_malloc_msg());
 	(*tokens)[i].expansions = new_ast_expansions(node->expansions);
 	if (!(*tokens)[i].expansions)
-		return (error_msg_return(MALLOC_ERROR_MSG));
+		return (error_malloc_msg());
 	return (OK);
 }
 

--- a/src/lexer/tokenizer_util.c
+++ b/src/lexer/tokenizer_util.c
@@ -1,0 +1,43 @@
+#include "minishell.h"
+
+t_AST_type	tokentype_check(t_scan_node *node)
+{
+	const char	*str = node->text;
+
+	if (is_str_equal(str, "|"))
+		return (PIPELINE);
+	if (is_str_equal(str, "<") || is_str_equal(str, "<<")
+		|| is_str_equal(str, ">") || is_str_equal(str, ">>"))
+		return (REDIRECT);
+	return (WORD);
+}
+
+void	tokens_print(t_token tokens[])
+{
+	int			i;
+	const char	*type_str[] = {
+		BWHT "💬 WORD", BBLU "🔗 PIPELINE",
+		BYEL "🔁 REDIRECT", BRED "🔥 COMMAND"};
+
+	i = -1;
+	while (tokens[++i].text)
+	{
+		printf("[%2d] %-12s" BGRN "\t%s\n" END,
+			i, type_str[tokens[i].type], tokens[i].text);
+		if (tokens[i].expansions)
+			expansions_print(tokens[i].expansions);
+	}
+}
+
+void	del_tokens(t_token tokens[])
+{
+	int	i;
+
+	i = -1;
+	while (tokens[++i].text)
+	{
+		free(tokens[i].text);
+		del_ast_expansions(tokens[i].expansions);
+	}
+	free(tokens);
+}

--- a/src/lexer/util2.c
+++ b/src/lexer/util2.c
@@ -22,15 +22,10 @@ bool	is_scan_continuos(char *buf, char c)
 	return (true);
 }
 
-bool	is_multi_expansions(t_expansion_scan_info info, int i)
+t_res	free_n_return(char **str, t_res result)
 {
-	char	last_quote;
-
-	if (info.str[i] == '$' && is_1stchar_valid(info.str[i + 1])
-		&& (!is_quotes_open(&last_quote, *info.buf) || last_quote != '\'')
-		&& !is_brace_open(*info.buf))
-		return (true);
-	return (false);
+	free(*str);
+	return (result);
 }
 
 t_res	free_arr_n_return(char *arr[], t_res result)

--- a/src/parser/del.c
+++ b/src/parser/del.c
@@ -45,16 +45,21 @@ void	del_ast_command(t_AST_COMMAND *command)
 	free(command);
 }
 
+void	del_ast_commands(t_AST_COMMAND *commands[])
+{
+	int	i;
+
+	i = -1;
+	while (commands[++i])
+		del_ast_command(commands[i]);
+	free(commands);
+}
+
 /*	avoid using it alone!
 	should be only called by t_shell methods
 */
 void	del_ast_script(t_AST_SCRIPT *script)
 {
-	int	i;
-
-	i = -1;
-	while (script->commands[++i])
-		del_ast_command(script->commands[i]);
-	free(script->commands);
+	del_ast_commands(script->commands);
 	free(script);
 }

--- a/src/parser/expander2.c
+++ b/src/parser/expander2.c
@@ -1,0 +1,36 @@
+#include "minishell.h"
+
+static t_res	buf_append_n_null_check(char **parr[], char **buf)
+{
+	if (!*buf)
+		return (error_malloc_msg());
+	if (ft_arr_append_free(parr, *buf) == ERR)
+		return (free_n_return(buf, error_malloc_msg()));
+	return (OK);
+}
+
+t_res	expansions_to_array(char **parr[], t_AST_NODE *node)
+{
+	const int	len = ft_strlen(node->text);
+	int			i;
+	int			begin;
+	char		*buf;
+
+	i = -1;
+	begin = 0;
+	while (node->expansions[++i])
+	{
+		buf = new_str_slice(node->text, begin, node->expansions[i]->begin);
+		if (buf_append_n_null_check(parr, &buf) == ERR)
+			return (ERR);
+		buf = new_str_slice(node->text,
+				node->expansions[i]->begin, node->expansions[i]->end + 1);
+		if (buf_append_n_null_check(parr, &buf) == ERR)
+			return (ERR);
+		begin = node->expansions[i]->end + 1;
+	}
+	buf = new_str_slice(node->text, begin, len);
+	if (buf_append_n_null_check(parr, &buf) == ERR)
+		return (ERR);
+	return (OK);
+}

--- a/src/parser/util1.c
+++ b/src/parser/util1.c
@@ -32,14 +32,6 @@ int	tokens_n_pipeline_count(int *size, t_token tokens[])
 	return (count);
 }
 
-int	commands_size(int pipe_count)
-{
-	if (pipe_count)
-		return (pipe_count + 1);
-	else
-		return (1);
-}
-
 void	command_data_init(
 	t_command_data *data, t_token tokens[], int begin, int end)
 {
@@ -68,4 +60,16 @@ void	command_data_init(
 				data->num_suffix++;
 		}
 	}
+}
+
+int	ast_nodes_len(t_AST_NODE *nodes[])
+{
+	int	i;
+
+	if (!nodes)
+		return (ERR);
+	i = 0;
+	while (nodes[i])
+		i++;
+	return (i);
 }

--- a/src/parser/util2.c
+++ b/src/parser/util2.c
@@ -10,14 +10,38 @@ bool	is_ast_command(t_AST_SCRIPT *script)
 	return (script->commands_len == 1);
 }
 
-int	ast_nodes_len(t_AST_NODE *nodes[])
+t_res	prefixes_parsing(
+	t_AST_COMMAND *command, t_token tokens[], int *prefix_i, int *i)
 {
-	int	i;
+	const t_redirect_op	op = redirection_option(tokens[*i].text);
 
-	if (!nodes)
+	command->prefixes[*prefix_i] = new_ast_redirect(
+			tokens[*i + 1].text, tokens[*i + 1].expansions, op);
+	*i += 1;
+	if (!command->prefixes[(*prefix_i)++])
+	{
+		del_ast_command(command);
 		return (ERR);
-	i = 0;
-	while (nodes[i])
-		i++;
-	return (i);
+	}
+	return (OK);
+}
+
+t_res	suffixes_parsing(
+	t_AST_COMMAND *command, t_token tokens[], int *suffix_i, int *i)
+{
+	const t_redirect_op	op = redirection_option(tokens[*i].text);
+
+	if (op == NOT_REDIR)
+		command->suffixes[*suffix_i] = new_ast_word(
+				tokens[*i].text, tokens[*i].expansions);
+	else
+		command->suffixes[*suffix_i] = new_ast_redirect(
+				tokens[*i + 1].text, tokens[*i + 1].expansions, op);
+	*i += (op != NOT_REDIR);
+	if (!command->suffixes[(*suffix_i)++])
+	{
+		del_ast_command(command);
+		return (ERR);
+	}
+	return (OK);
 }

--- a/src/prompt/prompt.c
+++ b/src/prompt/prompt.c
@@ -33,6 +33,7 @@ static void	prompt_run_line(char *line, t_shell *shell)
 	t_AST_SCRIPT	*script;
 
 	tokens = lexer(line);
+	free(line);
 	if (!tokens)
 		return ;
 	script = parser(tokens);

--- a/src/prompt/prompt.c
+++ b/src/prompt/prompt.c
@@ -33,12 +33,15 @@ static void	prompt_run_line(char *line, t_shell *shell)
 	t_AST_SCRIPT	*script;
 
 	tokens = lexer(line);
-	free(line);
 	if (!tokens)
 		return ;
-	script = parser(tokens, shell->env);
+	script = parser(tokens);
 	if (!script)
+	{
+		error_malloc_msg();
 		return ;
+	}
+	expander(script, shell->env);
 	shell_replace_script(shell, script);
 	ast_script_repr(shell->script);
 	if (is_ast_command(shell->script))

--- a/src/prompt/prompt.c
+++ b/src/prompt/prompt.c
@@ -41,7 +41,8 @@ static void	prompt_run_line(char *line, t_shell *shell)
 		error_malloc_msg();
 		return ;
 	}
-	expander(script, shell->env);
+	if (expander(script, shell->env) == ERR)
+		return ;
 	shell_replace_script(shell, script);
 	ast_script_repr(shell->script);
 	if (is_ast_command(shell->script))


### PR DESCRIPTION
### 개요
1. tokenizer, parser, expander 쪽 함수 NULL 체크 추가와 함수 분리 (+파일명 변경)
2. error.h에서 norm에 어긋난 부분 수정 (scanner쪽 파일들이 추가된 이유)

closes #79 