### PR TITLE
feat: :sparkles: Add exitcode for lexer & parser

### DIFF
--- a/include/error.h
+++ b/include/error.h
@@ -7,6 +7,7 @@
 # define BRACE_ERROR		"unclosed brace: "
 # define MULTILINE_ERROR	"multiline is not supported :(\n"
 # define MALLOC_ERROR		"failed to allocate memory :(\n"
+# define SUBSTITUTION_ERROR	": bad substitution\n"
 
 //@func
 /*
@@ -14,4 +15,5 @@
 
 t_res	error_msg_return(char *message[]);
 t_res	error_malloc_msg(void);
+t_res	error_with_exitcode(char *message[], t_dict *env, int exitcode);
 #endif

--- a/include/lexer.h
+++ b/include/lexer.h
@@ -1,11 +1,18 @@
 #ifndef LEXER_H
 # define LEXER_H
 
+typedef struct s_scan_data
+{
+	char	*buf;
+	char	*line;
+	int		idx;
+	t_dict	*env;
+	bool	env_flag;
+}	t_scan_data;
+
 typedef struct s_expansion_scan_info
 {
-	char			**buf;
-	char			*str;
-	int				*idx;
+	t_scan_data		*data;
 	int				start_i;
 	t_AST_expansion	**expansions;
 	int				begin;
@@ -37,7 +44,7 @@ typedef struct s_token
 /*
 ** < dollar_scan1.c > */
 
-t_res		dollar_scan(t_list **list, char **buf, char *str, int *idx);
+t_res		dollar_scan(t_list **list, t_scan_data *data);
 /*
 ** < dollar_scan2.c > */
 
@@ -57,11 +64,11 @@ void		expansions_print(t_AST_expansion *expansions[]);
 /*
 ** < lexer.c > */
 
-t_token		*lexer(char *line);
+t_token		*lexer(char *line, t_dict *env);
 /*
 ** < metachar_scan1.c > */
 
-t_res		metachar_scan(t_list **list, char **buf, char *str, int *idx);
+t_res		metachar_scan(t_list **list, t_scan_data *data);
 /*
 ** < metachar_scan2.c > */
 
@@ -71,7 +78,7 @@ bool		is_prev_metachar_attachable(char *str);
 /*
 ** < scanner.c > */
 
-t_res		scanner(t_list **scan_list, char *line);
+t_res		scanner(t_list **scan_list, char *line, t_dict *env);
 /*
 ** < scanner_list.c > */
 
@@ -86,7 +93,7 @@ bool		is_brace_open(char *str);
 t_res		list_element_create( t_list **element, char *buf,
 				t_AST_expansion **expansions);
 t_res		buf_to_list(t_list **list, char **buf);
-t_res		whitespace_scan(t_list **list, char **buf, char *str, int *idx);
+t_res		whitespace_scan(t_list **list, t_scan_data *data);
 /*
 ** < tokenizer.c > */
 

--- a/include/parser.h
+++ b/include/parser.h
@@ -26,6 +26,7 @@ t_res			expander(t_AST_SCRIPT *script, t_dict *env);
 ** < expander2.c > */
 
 t_res			expansions_to_array(char **parr[], t_AST_NODE *node);
+bool			is_substitution_valid(char *str);
 /*
 ** < new1.c > */
 

--- a/src/error/error.c
+++ b/src/error/error.c
@@ -17,3 +17,9 @@ t_res	error_malloc_msg(void)
 	return (error_msg_return(
 		(char *[]){BRED, MINISHELL, MALLOC_ERROR, END, NULL}));
 }
+
+t_res	error_with_exitcode(char *message[], t_dict *env, int exitcode)
+{
+	env_set_exitcode(env, exitcode);
+	return (error_msg_return(message));
+}

--- a/src/lexer/dollar_scan1.c
+++ b/src/lexer/dollar_scan1.c
@@ -2,13 +2,14 @@
 
 static t_res	expansion_last_check(t_expansion_scan_info *info, int *i)
 {
-	if (is_brace_open(*info->buf))
+	if (is_brace_open(info->data->buf))
 	{
 		del_ast_expansions(info->expansions);
-		free(*info->buf);
-		return (error_msg_return(
-				(char *[]){
-				BRED, MINISHELL, BRACE_ERROR, MULTILINE_ERROR, NULL}));
+		free(info->data->buf);
+		info->data->env_flag = true;
+		return (error_with_exitcode((char *[]){
+			BRED, MINISHELL, BRACE_ERROR, MULTILINE_ERROR, NULL},
+			info->data->env, 2));
 	}
 	if (info->end < info->begin)
 		if (expansions_update_with_brace(info, *i - 1, false) == ERR)
@@ -18,11 +19,11 @@ static t_res	expansion_last_check(t_expansion_scan_info *info, int *i)
 
 static t_res	brace_closed_n_other_check(t_expansion_scan_info *info, int *i)
 {
-	if (info->str[*i] == '}' && info->end < info->begin)
+	if (info->data->line[*i] == '}' && info->end < info->begin)
 		if (expansions_update_with_brace(info, *i, true) == ERR)
 			return (ERR);
-	if (ft_str_append(info->buf, info->str[*i]) == ERR)
-		return (free_n_return(info->buf, error_malloc_msg()));
+	if (ft_str_append(&info->data->buf, info->data->line[*i]) == ERR)
+		return (free_n_return(&info->data->buf, error_malloc_msg()));
 	return (OK);
 }
 
@@ -30,10 +31,10 @@ static t_res	expansion_scan_loop(t_expansion_scan_info *info, int *i)
 {
 	t_res	res;
 
-	while (is_scan_continuos(*info->buf, info->str[++*i]))
+	while (is_scan_continuos(info->data->buf, info->data->line[++*i]))
 	{
-		if (!is_brace_open(*info->buf)
-			&& !is_variable_char_valid(info->str[*i]))
+		if (!is_brace_open(info->data->buf)
+			&& !is_variable_char_valid(info->data->line[*i]))
 		{
 			if (info->end < info->begin)
 				if (expansions_update_with_brace(info, *i - 1, false) == ERR)
@@ -53,53 +54,48 @@ static t_res	expansion_scan_loop(t_expansion_scan_info *info, int *i)
 	return (expansion_last_check(info, i));
 }
 
-static t_res	expansion_scan(t_list **list, char **buf, char *str, int *idx)
+static t_res	expansion_scan(t_list **list, t_scan_data *data)
 {
 	t_expansion_scan_info	info;
 	int						i;
 	t_list					*list_element;
 
-	info.buf = buf;
-	info.str = str;
-	info.idx = idx;
-	info.start_i = ft_strlen(*buf);
-	i = *info.idx;
-	if (!is_1stchar_valid(str[i + 1]))
+	info.data = data;
+	info.start_i = ft_strlen(data->buf);
+	i = data->idx;
+	if (!is_1stchar_valid(data->line[i + 1]))
 		return (UNSET);
 	info.expansions = new_ast_expansions((t_AST_expansion *[]){NULL});
 	if (!info.expansions)
-		return (free_n_return(buf, error_malloc_msg()));
+		return (free_n_return(&data->buf, error_malloc_msg()));
 	if (expansion_location_init(&info, &i) == ERR)
 		return (ERR);
 	if (expansion_scan_loop(&info, &i) == ERR)
 		return (ERR);
-	if (list_element_create(&list_element, *info.buf, info.expansions) == ERR)
-		return (free_n_return(buf, ERR));
+	if (list_element_create(&list_element, data->buf, info.expansions) == ERR)
+		return (free_n_return(&data->buf, ERR));
 	ft_list_append(list, list_element);
-	*idx = --i;
+	data->idx = --i;
 	return (OK);
 }
 
-t_res	dollar_scan(t_list **list, char **buf, char *str, int *idx)
+t_res	dollar_scan(t_list **list, t_scan_data *data)
 {
-	int		i;
 	char	last_quote;
 	t_res	res;
 
-	i = *idx;
-	if (str[i] == '$')
+	if (data->line[data->idx] == '$')
 	{
-		if (is_quotes_open(&last_quote, *buf) && last_quote == '\'')
+		if (is_quotes_open(&last_quote, data->buf) && last_quote == '\'')
 			return (UNSET);
-		res = expansion_scan(list, buf, str, &i);
+		res = expansion_scan(list, data);
 		if (res == UNSET)
 			return (UNSET);
 		if (res == ERR)
 			return (ERR);
-		*idx = i;
-		free(*buf);
-		*buf = new_str("");
-		if (!buf)
+		free(data->buf);
+		data->buf = new_str("");
+		if (!data->buf)
 			return (error_malloc_msg());
 		return (OK);
 	}

--- a/src/lexer/dollar_scan2.c
+++ b/src/lexer/dollar_scan2.c
@@ -5,14 +5,14 @@ t_res	expansions_update_with_brace(
 {
 	char	*parameter;
 
-	info->end = end - *info->idx + info->start_i;
-	parameter = new_str_slice(*info->buf,
+	info->end = end - info->data->idx + info->start_i;
+	parameter = new_str_slice(info->data->buf,
 			info->begin + 1 + brace, info->end + 1 - brace);
 	if (!parameter)
-		return (free_n_return(info->buf, error_malloc_msg()));
+		return (free_n_return(&info->data->buf, error_malloc_msg()));
 	if (expansions_append_free(&info->expansions,
 			new_ast_expansion(parameter, info->begin, info->end)) == ERR)
-		return (free_arr_n_return((char *[]){*info->buf, parameter, NULL},
+		return (free_arr_n_return((char *[]){info->data->buf, parameter, NULL},
 			error_malloc_msg()));
 	free(parameter);
 	return (OK);
@@ -20,11 +20,12 @@ t_res	expansions_update_with_brace(
 
 t_res	expansion_location_init(t_expansion_scan_info *info, int *i)
 {
-	info->begin = *i - *info->idx + info->start_i;
-	if (ft_str_extend(info->buf, (char []){'$', info->str[++*i], '\0'}) == ERR)
-		return (free_n_return(info->buf, error_malloc_msg()));
+	info->begin = *i - info->data->idx + info->start_i;
+	if (ft_str_extend(&info->data->buf,
+			(char []){'$', info->data->line[++*i], '\0'}) == ERR)
+		return (free_n_return(&info->data->buf, error_malloc_msg()));
 	info->end = -1;
-	if (info->str[*i] == '?')
+	if (info->data->line[*i] == '?')
 		if (expansions_update_with_brace(info, *i, false) == ERR)
 			return (ERR);
 	return (OK);
@@ -34,9 +35,9 @@ bool	is_multi_expansions(t_expansion_scan_info info, int i)
 {
 	char	last_quote;
 
-	if (info.str[i] == '$' && is_1stchar_valid(info.str[i + 1])
-		&& (!is_quotes_open(&last_quote, *info.buf) || last_quote != '\'')
-		&& !is_brace_open(*info.buf))
+	if (info.data->line[i] == '$' && is_1stchar_valid(info.data->line[i + 1])
+		&& (!is_quotes_open(&last_quote, info.data->buf) || last_quote != '\'')
+		&& !is_brace_open(info.data->buf))
 		return (true);
 	return (false);
 }

--- a/src/lexer/scanner_util.c
+++ b/src/lexer/scanner_util.c
@@ -84,18 +84,18 @@ t_res	buf_to_list(t_list **list, char **buf)
 	return (OK);
 }
 
-t_res	whitespace_scan(t_list **list, char **buf, char *str, int *idx)
+t_res	whitespace_scan(t_list **list, t_scan_data *data)
 {
 	int	i;
 
-	i = *idx;
-	if (is_whitespace(str[i]) && !is_quotes_open(NULL, *buf))
+	i = data->idx;
+	if (is_whitespace(data->line[i]) && !is_quotes_open(NULL, data->buf))
 	{
-		if (buf_to_list(list, buf) == ERR)
+		if (buf_to_list(list, &data->buf) == ERR)
 			return (ERR);
-		while (is_whitespace(str[++i]))
+		while (is_whitespace(data->line[++i]))
 			;
-		*idx = --i;
+		data->idx = --i;
 		return (OK);
 	}
 	return (UNSET);

--- a/src/parser/expander1.c
+++ b/src/parser/expander1.c
@@ -1,5 +1,20 @@
 #include "minishell.h"
 
+static t_res	parameter_substitution(
+	char **parr[], t_AST_NODE *node, t_dict *env, int i)
+{
+	if (!is_substitution_valid((*parr)[i]))
+	{
+		error_msg_return((char *[]){
+			BRED, MINISHELL, (*parr)[i], SUBSTITUTION_ERROR, END, NULL});
+		return (ERR);
+	}
+	if (ft_str_replace(&(*parr)[i], new_str(
+			env_get(env, node->expansions[i >> 1]->parameter))) == ERR)
+		return (error_malloc_msg());
+	return (OK);
+}
+
 static t_res	word_expansion(char **parr[], t_AST_NODE *node, t_dict *env)
 {
 	int		i;
@@ -9,9 +24,8 @@ static t_res	word_expansion(char **parr[], t_AST_NODE *node, t_dict *env)
 	while ((*parr)[++i])
 	{
 		if (i % 2)
-			if (ft_str_replace(&(*parr)[i], new_str(
-					env_get(env, node->expansions[i >> 1]->parameter))) == ERR)
-				return (error_malloc_msg());
+			if (parameter_substitution(parr, node, env, i) == ERR)
+				return (ERR);
 	}
 	temp_str = new_str_join(*parr, '\0');
 	if (!temp_str)

--- a/src/parser/expander2.c
+++ b/src/parser/expander2.c
@@ -34,3 +34,23 @@ t_res	expansions_to_array(char **parr[], t_AST_NODE *node)
 		return (ERR);
 	return (OK);
 }
+
+bool	is_substitution_valid(char *str)
+{
+	const int	len = ft_strlen(str);
+	int			i;
+
+	if (str[len - 1] != '}')
+		return (true);
+	if (len == 3)
+		return (false);
+	i = 2;
+	if (!is_1stchar_valid(str[i]) || str[i] == '{')
+		return (false);
+	while (++i < len - 1)
+	{
+		if (!is_variable_char_valid(str[i]))
+			return (false);
+	}
+	return (true);
+}

--- a/src/prompt/prompt.c
+++ b/src/prompt/prompt.c
@@ -32,15 +32,18 @@ static void	prompt_run_line(char *line, t_shell *shell)
 	t_token			*tokens;
 	t_AST_SCRIPT	*script;
 
-	tokens = lexer(line);
+	tokens = lexer(line, shell->env);
 	free(line);
 	if (!tokens)
 		return ;
 	script = parser(tokens);
 	if (!script)
+	{
+		env_set_exitcode(shell->env, EXIT_FAILURE);
 		return ((void)error_malloc_msg());
+	}
 	if (expander(script, shell->env) == ERR)
-		return ;
+		return ((void)env_set_exitcode(shell->env, EXIT_FAILURE));
 	shell_replace_script(shell, script);
 	if (DEBUG)
 		ast_script_repr(shell->script);


### PR DESCRIPTION
### 개요
lexer와 parser 단계에서 발생하는 error에 대해 exitcode 저장 추가
- scanner, tokenizer에서 malloc error(1)와 syntax_error(2)를 구분하기 위해 env_flag 사용
- parser에서는 malloc error(1)만 발생해서 외부에서 세팅
- expander의 경우 bad substitution(1)의 exitcode가 malloc error(1)와 동일해서 외부에서 세팅

### 구현
```c
bool	is_substitution_valid(char *str);
```
bad substitution을 검사하기 위한 bool 함수
- `${}`를 사용할 때 `{}` 내부에 유효한 변수명이 아닌 경우는 bad substitution 출력
- 치환해야하는 문자열이 `}`로 끝나면 무조건 `${}` 구조인 점을 이용

closes #82