### PR TITLE
malloc -> ft_calloc으로 변경

### DIFF
--- a/include/api.h
+++ b/include/api.h
@@ -56,7 +56,7 @@ void	shell_open_redirects(t_shell *shell);
 void	shell_clear_script(t_shell *shell);
 void	shell_replace_script(t_shell *shell, t_AST_SCRIPT *script);
 int		shell_exec_script(t_shell *shell);
-void	shell_init(t_shell *shell, char *envp[]);
+t_res	shell_init(t_shell *shell, char *envp[]);
 void	del_shell(t_shell *shell);
 /*
 ** < signal.c > */

--- a/include/errormsg.h
+++ b/include/errormsg.h
@@ -6,7 +6,6 @@
 ** < error.c > */
 
 t_res	error_msg_return(char *message[]);
-t_res	error_malloc_msg(void);
 t_res	error_with_exitcode(char *message[], t_dict *env, int exitcode);
 t_res	error_msg_category(char *category, char *msg);
 t_res	error_msg_bad_opt(char *category, char *opt);

--- a/lib/src/dict/new.c
+++ b/lib/src/dict/new.c
@@ -24,7 +24,7 @@ t_dict	*new_dict(t_del_f del_value)
 {
 	t_dict	*dict;
 
-	dict = malloc(sizeof(t_dict));
+	dict = ft_calloc(sizeof(t_dict), 0);
 	if (!dict)
 		return (NULL);
 	if (dict_init(dict, del_value) == ERR)

--- a/lib/src/dict/util.c
+++ b/lib/src/dict/util.c
@@ -5,7 +5,7 @@ t_ditem	*new_ditem(const char *key, void *value)
 {
 	t_ditem	*item;
 
-	item = malloc(sizeof(t_ditem));
+	item = ft_calloc(sizeof(t_ditem), 0);
 	if (!item)
 		return (NULL);
 	item->key = new_str(key);

--- a/lib/src/ft_string/array.c
+++ b/lib/src/ft_string/array.c
@@ -5,10 +5,9 @@ char	**new_arr(char **arr)
 	int			i;
 	char		**new;
 
-	new = malloc(sizeof(char *) * 1);
+	new = ft_calloc(sizeof(char *), 0);
 	if (!new)
 		return (NULL);
-	new[0] = NULL;
 	if (arr)
 	{
 		i = -1;

--- a/lib/src/ft_string/array2.c
+++ b/lib/src/ft_string/array2.c
@@ -11,10 +11,9 @@ t_res	ft_arr_append(char **parr[], char *str)
 
 	if (arr_len == ERR)
 		return (ERR);
-	new = malloc((total_len + 1) * sizeof(char *));
+	new = ft_calloc(sizeof(char *), total_len);
 	if (!new)
 		return (ERR);
-	new[total_len] = NULL;
 	i = -1;
 	while (++i < arr_len)
 		new[i] = new_str((*parr)[i]);
@@ -46,10 +45,9 @@ t_res	ft_arr_extend(char **parr[], char *src[])
 
 	if (arr_len == ERR || src_len == ERR)
 		return (ERR);
-	new = malloc((total_len + 1) * sizeof(char *));
+	new = ft_calloc(sizeof(char *), total_len);
 	if (!new)
 		return (ERR);
-	new[total_len] = NULL;
 	i = -1;
 	while (++i < arr_len)
 		new[i] = new_str((*parr)[i]);

--- a/lib/src/ft_string/new.c
+++ b/lib/src/ft_string/new.c
@@ -6,10 +6,9 @@ char	*new_str(const char *src)
 	char	*new;
 
 	i = ft_strlen(src);
-	new = malloc((i + 1) * sizeof(char));
+	new = ft_calloc(sizeof(char), i);
 	if (!new)
 		return (NULL);
-	new[i] = '\0';
 	while (--i >= 0)
 		new[i] = src[i];
 	return (new);
@@ -27,10 +26,9 @@ char	*new_str_slice(char *str, int begin, int end)
 	if (str_len == ERR || begin < 0 || end < 0 || begin > end || end > str_len)
 		return (NULL);
 	i = end - begin;
-	new = malloc((i + 1) * sizeof(char));
+	new = ft_calloc(sizeof(char), i);
 	if (!new)
 		return (NULL);
-	new[i] = '\0';
 	while (--i >= 0)
 		new[i] = str[begin + i];
 	return (new);

--- a/lib/src/ft_string/split.c
+++ b/lib/src/ft_string/split.c
@@ -48,13 +48,12 @@ static char	**write_words(
 	{
 		while (str[i] == delimitor)
 			i++;
-		arr[word_idx] = malloc((wordlen(i, str, delimitor) + 1) * sizeof(char));
+		arr[word_idx] = ft_calloc(sizeof(char), wordlen(i, str, delimitor));
 		if (!arr[word_idx])
 		{
 			del_arr(arr);
 			return (NULL);
 		}
-		arr[word_idx][wordlen(i, str, delimitor)] = '\0';
 		j = 0;
 		while (str[i] && str[i] != delimitor)
 			arr[word_idx][j++] = str[i++];
@@ -70,9 +69,8 @@ char	**new_str_split(char const *str, char delimitor)
 	if (!str)
 		return (NULL);
 	words = count_words(str, delimitor);
-	strarr = malloc((words + 1) * sizeof(char *));
+	strarr = ft_calloc(sizeof(char *), words);
 	if (!strarr)
 		return (NULL);
-	strarr[words] = NULL;
 	return (write_words(strarr, words, str, delimitor));
 }

--- a/lib/src/list/list.c
+++ b/lib/src/list/list.c
@@ -4,7 +4,7 @@ t_list	*new_list(void *content)
 {
 	t_list	*new_list;
 
-	new_list = (t_list *)malloc(sizeof(t_list));
+	new_list = ft_calloc(sizeof(t_list), 0);
 	if (new_list == NULL)
 		return (NULL);
 	new_list->content = content;

--- a/lib/src/system/calloc.c
+++ b/lib/src/system/calloc.c
@@ -9,7 +9,7 @@ void	*ft_calloc(size_t size, size_t count)
 	ptr = malloc(allocated_space);
 	if (!ptr)
 	{
-		error_syscall("fd_calloc");
+		error_syscall("ft_calloc");
 		return (NULL);
 	}
 	i = 0;

--- a/src/api/env1.c
+++ b/src/api/env1.c
@@ -6,6 +6,8 @@ t_dict	*new_env(char *envp[])
 	t_dict	*env;
 
 	env = new_dict(free);
+	if (!env)
+		return (NULL);
 	env->exitcode = EXIT_SUCCESS;
 	env->exitcode_str = new_itoa(EXIT_SUCCESS);
 	i = -1;

--- a/src/api/env2.c
+++ b/src/api/env2.c
@@ -29,4 +29,3 @@ char	*env_get(t_dict *env, char *key)
 		return (env->exitcode_str);
 	return (dict_get_default(env, key, ""));
 }
-

--- a/src/api/shell.c
+++ b/src/api/shell.c
@@ -29,11 +29,14 @@ int	shell_exec_script(t_shell *shell)
 	return (exitcode);
 }
 
-void	shell_init(t_shell *shell, char *envp[])
+t_res	shell_init(t_shell *shell, char *envp[])
 {
 	shell->env = new_env(envp);
+	if (!shell->env)
+		return (ERR);
 	shell->script = NULL;
 	prompt_init(&shell->prompt);
+	return (OK);
 }
 
 void	del_shell(t_shell *shell)
@@ -42,4 +45,3 @@ void	del_shell(t_shell *shell)
 	del_prompt(&shell->prompt);
 	shell_clear_script(shell);
 }
-

--- a/src/api/util.c
+++ b/src/api/util.c
@@ -4,5 +4,6 @@
 void	api_exit(t_shell *shell, int exitcode)
 {
 	del_shell(shell);
+	system("leaks minishell > leaks_result; cat leaks_result | grep leaked && rm -rf leaks_result");
 	exit(exitcode);
 }

--- a/src/api/util.c
+++ b/src/api/util.c
@@ -4,6 +4,6 @@
 void	api_exit(t_shell *shell, int exitcode)
 {
 	del_shell(shell);
-	system("leaks minishell > leaks_result; cat leaks_result | grep leaked && rm -rf leaks_result");
+	// system("leaks minishell > leaks_result; cat leaks_result | grep leaked && rm -rf leaks_result");
 	exit(exitcode);
 }

--- a/src/errormsg/error.c
+++ b/src/errormsg/error.c
@@ -11,12 +11,6 @@ t_res	error_msg_return(char *message[])
 	return (ERR);
 }
 
-t_res	error_malloc_msg(void)
-{
-	return (error_msg_return(
-			(char *[]){BRED, MINISHELL, MALLOC_ERROR, END, NULL}));
-}
-
 t_res	error_with_exitcode(char *message[], t_dict *env, int exitcode)
 {
 	env_set_exitcode(env, exitcode);

--- a/src/exec/util.c
+++ b/src/exec/util.c
@@ -28,4 +28,3 @@ void	receive_input_from_pipe(t_fd pipefd[PIPE_SIZE])
 	dup2(pipefd[PIPE_READ], STDIN_FILENO);
 	close(pipefd[PIPE_READ]);
 }
-

--- a/src/lexer/tokenizer.c
+++ b/src/lexer/tokenizer.c
@@ -14,7 +14,7 @@ t_res	quotes_remove_loop(char **new, char *last_quote, bool *open, char c)
 		return (OK);
 	}
 	if (ft_str_append(new, c) == ERR)
-		return (free_n_return(new, error_malloc_msg()));
+		return (free_n_return(new, ERR));
 	return (OK);
 }
 
@@ -27,10 +27,7 @@ char	*new_quotes_remove(const char *str)
 
 	new = new_str("");
 	if (!new)
-	{
-		error_malloc_msg();
 		return (NULL);
-	}
 	open = false;
 	i = -1;
 	while (str[++i])
@@ -48,10 +45,10 @@ t_res	node_tokenize(t_token *tokens[], t_scan_node *node, int i)
 	else
 		(*tokens)[i].text = new_str(node->text);
 	if (!(*tokens)[i].text)
-		return (error_malloc_msg());
+		return (ERR);
 	(*tokens)[i].expansions = new_ast_expansions(node->expansions);
 	if (!(*tokens)[i].expansions)
-		return (error_malloc_msg());
+		return (ERR);
 	return (OK);
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -6,7 +6,8 @@ int	main(int argc, char *argv[], char *envp[])
 
 	(void)argc;
 	(void)argv;
-	shell_init(&shell, envp);
+	if (shell_init(&shell, envp) == ERR)
+		return (EXIT_FAILURE);
 	shell_prompt(&shell);
 	del_shell(&shell);
 	return (0);

--- a/src/parser/expander1.c
+++ b/src/parser/expander1.c
@@ -11,7 +11,7 @@ static t_res	parameter_substitution(
 	}
 	if (ft_str_replace(&(*parr)[i], new_str(
 			env_get(env, node->expansions[i >> 1]->parameter))) == ERR)
-		return (error_malloc_msg());
+		return (ERR);
 	return (OK);
 }
 
@@ -29,7 +29,7 @@ static t_res	word_expansion(char **parr[], t_AST_NODE *node, t_dict *env)
 	}
 	temp_str = new_str_join(*parr, '\0');
 	if (!temp_str)
-		return (error_malloc_msg());
+		return (ERR);
 	if (ft_str_replace(&node->text, new_quotes_remove(temp_str)) == ERR)
 		return (ERR);
 	del_ast_expansions(node->expansions);
@@ -52,7 +52,7 @@ static t_res	node_expansion(t_AST_NODE *node, t_dict *env)
 		return (UNSET);
 	text_split = new_arr((char *[]){NULL});
 	if (!text_split)
-		return (error_malloc_msg());
+		return (ERR);
 	if (expansions_to_array(&text_split, node) == ERR)
 	{
 		del_arr(text_split);

--- a/src/parser/expander2.c
+++ b/src/parser/expander2.c
@@ -3,9 +3,9 @@
 static t_res	buf_append_n_null_check(char **parr[], char **buf)
 {
 	if (!*buf)
-		return (error_malloc_msg());
+		return (ERR);
 	if (ft_arr_append_free(parr, *buf) == ERR)
-		return (free_n_return(buf, error_malloc_msg()));
+		return (free_n_return(buf, ERR));
 	return (OK);
 }
 

--- a/src/parser/new1.c
+++ b/src/parser/new1.c
@@ -4,7 +4,7 @@ t_AST_expansion	*new_ast_expansion(char *parameter, int begin, int end)
 {
 	t_AST_expansion	*expansion;
 
-	expansion = malloc(sizeof(t_AST_expansion));
+	expansion = ft_calloc(sizeof(t_AST_expansion), 0);
 	if (!expansion)
 		return (NULL);
 	expansion->parameter = new_str(parameter);
@@ -46,7 +46,7 @@ t_AST_NODE	*new_ast_word(
 {
 	t_AST_NODE	*node;
 
-	node = malloc(sizeof(t_AST_NODE));
+	node = ft_calloc(sizeof(t_AST_NODE), 0);
 	if (!node)
 		return (NULL);
 	node->op = NOT_REDIR;

--- a/src/parser/new2.c
+++ b/src/parser/new2.c
@@ -15,7 +15,7 @@ t_AST_COMMAND	*new_ast_command(t_token tokens[], t_command_data data)
 {
 	t_AST_COMMAND	*new;
 
-	new = malloc(sizeof(t_AST_COMMAND));
+	new = ft_calloc(sizeof(t_AST_COMMAND), 0);
 	if (!new)
 		return (NULL);
 	if (data.name_index == -1)
@@ -34,7 +34,7 @@ t_AST_SCRIPT	*new_ast_script(t_AST_COMMAND *commands[], int commands_len)
 {
 	t_AST_SCRIPT	*script;
 
-	script = malloc(sizeof(t_AST_SCRIPT));
+	script = ft_calloc(sizeof(t_AST_SCRIPT), 0);
 	if (!script)
 		return (NULL);
 	script->commands = commands;

--- a/src/prompt/prompt.c
+++ b/src/prompt/prompt.c
@@ -40,7 +40,7 @@ static void	prompt_run_line(char *line, t_shell *shell)
 	if (!script)
 	{
 		env_set_exitcode(shell->env, EXIT_FAILURE);
-		return ((void)error_malloc_msg());
+		return ;
 	}
 	if (expander(script, shell->env) == ERR)
 		return ((void)env_set_exitcode(shell->env, EXIT_FAILURE));

--- a/src/scanner/dollar_scan1.c
+++ b/src/scanner/dollar_scan1.c
@@ -8,7 +8,7 @@ static t_res	expansion_last_check(t_expansion_scan_info *info, int *i)
 		free(info->data->buf);
 		info->data->env_flag = true;
 		return (error_with_exitcode((char *[]){
-			BRED, MINISHELL, BRACE_ERROR, MULTILINE_ERROR, NULL},
+				BRED, MINISHELL, BRACE_ERROR, MULTILINE_ERROR, NULL},
 			info->data->env, 2));
 	}
 	if (info->end < info->begin)
@@ -23,7 +23,7 @@ static t_res	brace_closed_n_other_check(t_expansion_scan_info *info, int *i)
 		if (expansions_update_with_brace(info, *i, true) == ERR)
 			return (ERR);
 	if (ft_str_append(&info->data->buf, info->data->line[*i]) == ERR)
-		return (free_n_return(&info->data->buf, error_malloc_msg()));
+		return (free_n_return(&info->data->buf, ERR));
 	return (OK);
 }
 
@@ -67,7 +67,7 @@ static t_res	expansion_scan(t_list **list, t_scan_data *data)
 		return (UNSET);
 	info.expansions = new_ast_expansions((t_AST_expansion *[]){NULL});
 	if (!info.expansions)
-		return (free_n_return(&data->buf, error_malloc_msg()));
+		return (free_n_return(&data->buf, ERR));
 	if (expansion_location_init(&info, &i) == ERR)
 		return (ERR);
 	if (expansion_scan_loop(&info, &i) == ERR)
@@ -96,7 +96,7 @@ t_res	dollar_scan(t_list **list, t_scan_data *data)
 		free(data->buf);
 		data->buf = new_str("");
 		if (!data->buf)
-			return (error_malloc_msg());
+			return (ERR);
 		return (OK);
 	}
 	return (UNSET);

--- a/src/scanner/dollar_scan2.c
+++ b/src/scanner/dollar_scan2.c
@@ -9,11 +9,11 @@ t_res	expansions_update_with_brace(
 	parameter = new_str_slice(info->data->buf,
 			info->begin + 1 + brace, info->end + 1 - brace);
 	if (!parameter)
-		return (free_n_return(&info->data->buf, error_malloc_msg()));
+		return (free_n_return(&info->data->buf, ERR));
 	if (expansions_append_free(&info->expansions,
 			new_ast_expansion(parameter, info->begin, info->end)) == ERR)
 		return (free_arr_n_return((char *[]){info->data->buf, parameter, NULL},
-			error_malloc_msg()));
+			ERR));
 	free(parameter);
 	return (OK);
 }
@@ -23,7 +23,7 @@ t_res	expansion_location_init(t_expansion_scan_info *info, int *i)
 	info->begin = *i - info->data->idx + info->start_i;
 	if (ft_str_extend(&info->data->buf,
 			(char []){'$', info->data->line[++*i], '\0'}) == ERR)
-		return (free_n_return(&info->data->buf, error_malloc_msg()));
+		return (free_n_return(&info->data->buf, ERR));
 	info->end = -1;
 	if (info->data->line[*i] == '?')
 		if (expansions_update_with_brace(info, *i, false) == ERR)

--- a/src/scanner/metachar_scan1.c
+++ b/src/scanner/metachar_scan1.c
@@ -26,7 +26,7 @@ static t_res	metastr_append(
 		metastr->prev = metastr->str;
 		metastr->str = new_str((char []){c, '\0'});
 		if (!metastr->str)
-			return (free_n_return(&metastr->prev, error_malloc_msg()));
+			return (free_n_return(&metastr->prev, ERR));
 		return (OK);
 	}
 	else

--- a/src/scanner/metachar_scan2.c
+++ b/src/scanner/metachar_scan2.c
@@ -5,7 +5,7 @@ t_res	metachar_attachable(char **pstr, char prev_c, char c)
 	if (prev_c != '|' && ft_strlen(*pstr) == 1 && c == prev_c)
 	{
 		if (ft_str_append(pstr, c) == ERR)
-			return (free_n_return(pstr, error_malloc_msg()));
+			return (free_n_return(pstr, ERR));
 		return (OK);
 	}
 	return (UNSET);
@@ -15,10 +15,10 @@ t_res	metastr_init(t_metastr *metastr, char c)
 {
 	metastr->str = new_str((char []){c, '\0'});
 	if (!metastr->str)
-		return (error_malloc_msg());
+		return (ERR);
 	metastr->prev = new_str("");
 	if (!metastr->prev)
-		return (free_n_return(&metastr->str, error_malloc_msg()));
+		return (free_n_return(&metastr->str, ERR));
 	return (OK);
 }
 

--- a/src/scanner/scanner.c
+++ b/src/scanner/scanner.c
@@ -45,7 +45,7 @@ static t_res	scanner_loop(t_list **scan_list, t_scan_data *data)
 		if (scan_res == ERR)
 			return (ERR);
 		if (ft_str_append(&data->buf, data->line[data->idx]) == ERR)
-			return (free_n_return(&data->buf, error_malloc_msg()));
+			return (free_n_return(&data->buf, ERR));
 	}
 	return (scan_last_check(scan_list, data));
 }
@@ -63,7 +63,7 @@ t_res	scanner(t_list **scan_list, char *line, t_dict *env)
 	if (!data.buf)
 	{
 		env_set_exitcode(env, EXIT_FAILURE);
-		return (error_malloc_msg());
+		return (ERR);
 	}
 	res = scanner_loop(scan_list, &data);
 	if (res == OK)

--- a/src/scanner/scanner_list.c
+++ b/src/scanner/scanner_list.c
@@ -4,7 +4,7 @@ t_scan_node	*new_scan_node(char *str, t_AST_expansion **arr)
 {
 	t_scan_node	*new;
 
-	new = (t_scan_node *)malloc(sizeof(t_scan_node));
+	new = ft_calloc(sizeof(t_scan_node), 0);
 	if (!new)
 		return (NULL);
 	new->text = str;

--- a/src/scanner/util.c
+++ b/src/scanner/util.c
@@ -54,15 +54,15 @@ t_res	list_element_create(
 	*element = NULL;
 	str = new_str(buf);
 	if (!str)
-		return (error_malloc_msg());
+		return (ERR);
 	content = new_scan_node(str, expansions);
 	if (!content)
-		return (free_n_return(&str, error_malloc_msg()));
+		return (free_n_return(&str, ERR));
 	*element = new_list(content);
 	if (!element)
 	{
 		del_scan_node(content);
-		return (error_malloc_msg());
+		return (ERR);
 	}
 	return (OK);
 }
@@ -80,7 +80,7 @@ t_res	buf_to_list(t_list **list, char **buf)
 	free(*buf);
 	*buf = new_str("");
 	if (!*buf)
-		return (error_malloc_msg());
+		return (ERR);
 	return (OK);
 }
 


### PR DESCRIPTION
### 개요
malloc()이 쓰인 부분을 전부 ft_calloc()으로 변경
- ft_calloc에서 malloc 실패 시, error_syscall()을 호출해 에러메세지 출력
- error_malloc_msg() 삭제
- main에서 shell_init이 ft_calloc에 의해 실패했을 경우 EXIT_FAILURE 최종 반환