### PR TITLE
refactor: :recycle: Refactor shell_heredoc and check norm

### DIFF
--- a/include/api.h
+++ b/include/api.h
@@ -30,6 +30,10 @@ bool	is_path(char *path);
 bool	is_executable_exists(char *file, t_dict *env);
 char	*new_executable_from_env(char *file, t_dict *env);
 /*
+** < heredoc.c > */
+
+t_fd	shell_heredoc(t_shell *shell, const char *eof);
+/*
 ** < path.c > */
 
 char	**new_names_from_path(char *name, t_dict *env);

--- a/makefile
+++ b/makefile
@@ -26,7 +26,7 @@ lexerV   := lexer tokenizer util
 parserV  := parser new1 new2 del util1 util2 expander1 expander2 heredoc_parser
 shellV   := shell script
 promptV  := prompt interrupt ps util
-apiV     := redirect signal path file util env1 env2
+apiV     := redirect heredoc signal path file util env1 env2
 execV    := context exec pipe argv util
 builtinV := builtin cd echo env export unset pwd util checks
 treeV    := repr1 repr2
@@ -95,7 +95,7 @@ leak: docs all cls
 supp: docs all cls
 	@$(call log, Y, Creating Leak Suppressions,...)
 	@valgrind $(VFLAGS) \
-		--log-file=supp2.txt\
+		--log-file=supp3.txt\
 		--gen-suppressions=all ./$(NAME)
 
 .PHONY: $(NAME) all re clean fclean test red docs $(LIBFT)

--- a/src/api/heredoc.c
+++ b/src/api/heredoc.c
@@ -1,0 +1,47 @@
+#include "minishell.h"
+
+// ctrl + d in heredoc readline
+static void	eof_heredoc(t_shell *shell)
+{
+	cursor_up();
+	ft_write(1, shell->prompt.ps2);
+}
+
+static t_res	process_heredoc(t_shell *shell, t_fd fd, char **pstr)
+{
+	if (replace_line_heredoc(pstr, shell->env) == ERR)
+		return (ERR);
+	ft_writes(fd, (char *[]){*pstr, "\n", NULL});
+	free(*pstr);
+	return (OK);
+}
+
+/*	get input for heredoc
+	returns opened fd that points to it
+*/
+t_fd	shell_heredoc(t_shell *shell, const char *eof)
+{
+	char	*line;
+	t_fd	pipefd[PIPE_SIZE];
+
+	if (pipe(pipefd) == ERR)
+		return (ERR);
+	while (true)
+	{
+		line = readline(shell->prompt.ps2);
+		if (!line)
+		{
+			eof_heredoc(shell);
+			break ;
+		}
+		else if (is_str_equal(line, eof))
+			break ;
+		else
+			if (process_heredoc(shell, pipefd[PIPE_WRITE], &line) == ERR)
+				break ;
+	}
+	if (line)
+		free(line);
+	close(pipefd[PIPE_WRITE]);
+	return (pipefd[PIPE_READ]);
+}

--- a/src/api/redirect.c
+++ b/src/api/redirect.c
@@ -1,40 +1,5 @@
 #include "minishell.h"
 
-/*	get input for heredoc
-	returns opened fd that points to it
-*/
-static t_fd	shell_heredoc(t_shell *shell, const char *eof)
-{
-	char	*line;
-	t_fd	pipefd[PIPE_SIZE];
-
-	if (pipe(pipefd) == ERR)
-		return (ERR);
-	while (true)
-	{
-		line = readline(shell->prompt.ps2);
-		if (!line)
-		{
-			cursor_up();
-			ft_write(1, shell->prompt.ps2);
-			break ;
-		}
-		else if (is_str_equal(line, eof))
-			break ;
-		else
-		{
-			if (replace_line_heredoc(&line, shell->env) == ERR)
-				break ;
-			ft_writes(pipefd[PIPE_WRITE], (char *[]){line, "\n", NULL});
-			free(line);
-		}
-	}
-	if (line)
-		free(line);
-	close(pipefd[PIPE_WRITE]);
-	return (pipefd[PIPE_READ]);
-}
-
 /*	currently:
 	REDIR_INPUT = 0,
 	REDIR_HEREDOC = 1,

--- a/src/api/util.c
+++ b/src/api/util.c
@@ -4,7 +4,6 @@
 void	api_exit(t_shell *shell, int exitcode)
 {
 	del_shell(shell);
-	// system("leaks minishell > leaks_result; cat leaks_result | grep leaked && rm -rf leaks_result");
 	exit(exitcode);
 }
 

--- a/src/parser/heredoc_parser.c
+++ b/src/parser/heredoc_parser.c
@@ -22,15 +22,16 @@ static t_res	list_tokenize_n_expand(char **line, t_list *list, t_dict *env)
 {
 	t_scan_node	*node;
 	t_AST_NODE	*word;
+	t_res		res;
 
 	node = (t_scan_node *)list->content;
 	word = new_ast_word(node->text, node->expansions);
-	if (node_expansion(word, env, HEREDOC) == ERR)
-		return (ERR);
-	ft_str_replace(line, new_str(word->text));
+	res = node_expansion(word, env, HEREDOC);
+	if (res == OK)
+		ft_str_replace(line, new_str(word->text));
 	del_ast_node(word);
 	del_list(&list, del_scan_node);
-	return (OK);
+	return (res);
 }
 
 // mini parser for HEREDOC(`<<`)

--- a/src/scanner/dollar_scan2.c
+++ b/src/scanner/dollar_scan2.c
@@ -9,7 +9,7 @@ t_res	expansions_update_with_brace(
 	parameter = new_str_slice(info->data->buf,
 			info->begin + 1 + brace, info->end + 1 - brace);
 	expansions_append_free(&info->expansions,
-			new_ast_expansion(parameter, info->begin, info->end));
+		new_ast_expansion(parameter, info->begin, info->end));
 	free(parameter);
 	return (OK);
 }
@@ -18,7 +18,7 @@ t_res	expansion_location_init(t_expansion_scan_info *info, int *i)
 {
 	info->begin = *i - info->data->idx + info->start_i;
 	ft_str_extend(&info->data->buf,
-			(char []){'$', info->data->line[++*i], '\0'});
+		(char []){'$', info->data->line[++*i], '\0'});
 	info->end = -1;
 	if (info->data->line[*i] == '?')
 		expansions_update_with_brace(info, *i, false);

--- a/src/scanner/metachar_scan1.c
+++ b/src/scanner/metachar_scan1.c
@@ -55,7 +55,7 @@ static t_res	metachar_valid_check(t_list **list, t_scan_data *data)
 	while (is_metachar(data->line[++metastr.i]) || !data->line[metastr.i])
 	{
 		if (is_metachar_attachable(&metastr.str,
-			data->line[metastr.i - 1], data->line[metastr.i]))
+				data->line[metastr.i - 1], data->line[metastr.i]))
 			continue ;
 		res = metastr_append(list, &metastr, data->line[metastr.i], data);
 		if (res == UNSET)


### PR DESCRIPTION
### 개요
shell_heredoc() -> heredoc.c로 분리 및 norm 체크
- 추가로 heredoc_parser에서 발생하는 메모리 누수 해결

#101