### PR TITLE
fix: :bug: Fix expand empty string error

### DIFF
--- a/src/exec/exec.c
+++ b/src/exec/exec.c
@@ -67,6 +67,8 @@ int	api_exec_cmd_at(t_shell *shell, int index)
 
 	cmd = shell->script->commands[index];
 	text = cmd->name->text;
+	if (is_line_empty(text))
+		return (EXIT_SUCCESS);
 	if (is_builtin(text))
 		return (builtin_run(cmd, shell));
 	else


### PR DESCRIPTION
치환된 문자열이 빈 문자열인 경우 별다른 동작없이 넘어가도록 수정

- closes #132